### PR TITLE
Add Nix Flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@ secrets.bass
 # coverage
 cover.out
 cover.html
+
+# nix
+/.direnv
+/result

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,16 @@
+{ lib, buildGoModule }:
+
+buildGoModule rec {
+  pname = "bass";
+  version = "0.0.1-alpha";
+  src = ./.;
+
+  # get using ./hack/get-nix-vendorsha
+  vendorSha256 = "sha256-YauCD97LRd649ag/EQ8VrNc90oXszk/brBcj33mvjrM=";
+
+  ldflags = [
+    "-X github.com/vito/bass.Version=${version}"
+  ];
+
+  subPackages = [ "cmd/bass" "cmd/bass-lsp" ];
+}

--- a/default.nix
+++ b/default.nix
@@ -1,4 +1,8 @@
-{ lib, buildGoModule }:
+{ lib
+, buildGoModule
+, makeWrapper
+, buildkit
+}:
 
 buildGoModule rec {
   pname = "bass";
@@ -8,9 +12,16 @@ buildGoModule rec {
   # get using ./hack/get-nix-vendorsha
   vendorSha256 = "sha256-YauCD97LRd649ag/EQ8VrNc90oXszk/brBcj33mvjrM=";
 
+  nativeBuildInputs = [ makeWrapper ];
+
   ldflags = [
     "-X github.com/vito/bass.Version=${version}"
   ];
+
+  postInstall = ''
+    wrapProgram $out/bin/bass \
+      --prefix PATH : ${lib.makeBinPath [ buildkit ]}
+  '';
 
   subPackages = [ "cmd/bass" "cmd/bass-lsp" ];
 }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1640418986,
+        "narHash": "sha256-a8GGtxn2iL3WAkY5H+4E0s3Q7XJt6bTOvos9qqxT5OQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "5c37ad87222cfc1ec36d6cd1364514a9efc2f7f2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,40 @@
+{
+  description = "a low fidelity scripting language for building reproducible artifacts";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    let
+      supportedSystems = [
+        "aarch64-darwin"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "x86_64-linux"
+      ];
+    in
+    flake-utils.lib.eachSystem supportedSystems (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+      in
+      rec {
+        packages.bass = pkgs.callPackage ./default.nix { };
+
+        defaultPackage = packages.bass;
+
+        defaultApp = {
+          type = "app";
+          program = "${packages.bass}/bin/bass";
+        };
+
+        devShell = pkgs.mkShell {
+          nativeBuildInputs = [
+            pkgs.go
+            pkgs.golangci-lint
+            pkgs.gopls
+          ];
+        };
+      });
+}

--- a/hack/get-nix-vendorsha
+++ b/hack/get-nix-vendorsha
@@ -1,0 +1,4 @@
+#!/usr/bin/env nix-shell
+#!nix-shell -p nix-prefetch -i bash
+
+nix-prefetch '{ sha256 }: (callPackage (import ./default.nix) { }).go-modules.overrideAttrs (_: { modSha256 = sha256; })'


### PR DESCRIPTION
Allows for:
- Convenient usage - `nix run github:vito/bass`
- Pinned Go version (when using Nix to build)
- Development environment which just works (add `use flake` into `.envrc`)

See also:
- https://nixos.wiki/wiki/Flakes
- https://www.tweag.io/blog/2020-05-25-flakes/
- https://serokell.io/blog/practical-nix-flakes