### PR TITLE
generalize paths as combiners, add github path root

### DIFF
--- a/binding_test.go
+++ b/binding_test.go
@@ -151,6 +151,36 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
+			Name:     "file match",
+			Params:   bass.FilePath{"foo"},
+			Value:    bass.FilePath{"foo"},
+			Bindings: bass.Bindings{},
+		},
+		{
+			Name:   "file mismatch",
+			Params: bass.FilePath{"foo"},
+			Value:  bass.FilePath{"bar"},
+			Err: bass.BindMismatchError{
+				Need: bass.FilePath{"foo"},
+				Have: bass.FilePath{"bar"},
+			},
+		},
+		{
+			Name:     "dir match",
+			Params:   bass.DirPath{"foo"},
+			Value:    bass.DirPath{"foo"},
+			Bindings: bass.Bindings{},
+		},
+		{
+			Name:   "dir mismatch",
+			Params: bass.DirPath{"foo"},
+			Value:  bass.DirPath{"bar"},
+			Err: bass.BindMismatchError{
+				Need: bass.DirPath{"foo"},
+				Have: bass.DirPath{"bar"},
+			},
+		},
+		{
 			Name:     "null match",
 			Params:   bass.Null{},
 			Value:    bass.Null{},

--- a/ci/shipit
+++ b/ci/shipit
@@ -4,13 +4,8 @@
 (use (.git "alpine/git")
      (*dir*/../project)
      (*dir*/../secrets)
-     (*dir*/bass))
-     ; (git:github/vito/bass/main/gh/release "vito/bass" secrets:*access-token*)
-
-(def release
-  (let [repo "https://github.com/vito/tabs"
-        tabs (git:checkout repo (git:ls-remote repo "main"))]
-    (load (tabs/gh/release "vito/bass" secrets:*access-token*))))
+     (*dir*/bass)
+     (git:github/vito/tabs/ref/main/gh/release "vito/bass" secrets:*access-token*))
 
 ; sha: git sha to tag
 ;

--- a/demos/booklit/build.bass
+++ b/demos/booklit/build.bass
@@ -1,15 +1,6 @@
 #!/usr/bin/env bass
 
-(def git
-  (load (.git "alpine/git")))
+(use (.git "alpine/git")
+     (git:github/vito/booklit/ref/HEAD/project))
 
-(def repo
-  "https://github.com/vito/booklit")
-
-(def latest-booklit
-  (git:checkout repo (git:ls-remote repo "HEAD")))
-
-(def booklit
-  (load (latest-booklit/project)))
-
-(emit (booklit:build latest-booklit "v0.0.0-dev" "linux" "amd64") *stdout*)
+(emit (project:build project:*root* "v0.0.0-dev" "linux" "amd64") *stdout*)

--- a/demos/booklit/docs.bass
+++ b/demos/booklit/docs.bass
@@ -1,13 +1,10 @@
 #!/usr/bin/env bass
 
-(def git
-  (load (.git "alpine/git")))
-
-(def repo
-  "https://github.com/vito/booklit")
+(use (.git "alpine/git")
+     (git:github/vito/booklit/ref/HEAD/project))
 
 (def latest-booklit
-  (git:checkout repo (git:ls-remote repo "HEAD")))
+  project:*root*)
 
 (-> (from "golang"
       ($ latest-booklit/scripts/build-docs $latest-booklit))

--- a/demos/booklit/test-last-10.bass
+++ b/demos/booklit/test-last-10.bass
@@ -1,28 +1,17 @@
 #!/usr/bin/env bass
 
+(use (.git "alpine/git")
+     (git:github/vito/booklit/ref/HEAD/project))
+
 (def testflags *args*)
-
-(def git
-  (load (.git "alpine/git")))
-
-(def repo
-  "https://github.com/vito/booklit")
-
-(def head
-  (git:ls-remote repo "HEAD"))
-
-(def latest
-  (git:checkout repo head))
-
-(def project
-  (load (latest/project)))
 
 (each
   (-> ($ git rev-list "HEAD~10..HEAD")
       (response-from :stdout :unix-table)
-      (in-dir latest)
+      (in-dir project:*root*)
       (in-image "alpine/git")
       run)
   (fn [[sha]]
-    (logf "running tests for %s" sha)
-    (run (project:test (git:checkout repo sha) testflags))))
+    (let [src (git:github/vito/booklit/sha/ (string->dir sha))]
+      (logf "running tests for %s" sha)
+      (run (project:test src testflags)))))

--- a/demos/booklit/test.bass
+++ b/demos/booklit/test.bass
@@ -1,20 +1,6 @@
 #!/usr/bin/env bass
 
-(def testflags *args*)
+(use (.git "alpine/git")
+     (git:github/vito/booklit/ref/HEAD/project))
 
-(use (.git "alpine/git"))
-
-(def repo
-  "https://github.com/vito/booklit")
-
-(def latest
-  (git:checkout repo (git:ls-remote repo "HEAD")))
-
-(def project
-  (load (latest/project)))
-
-; TODO: once github.com is implemented
-; (use (.git "alpine/git")
-;      (git:github.com/vito/booklit/HEAD/project))
-
-(run (project:test latest testflags))
+(run (project:test project:*root* *args*))

--- a/demos/fib-tail-loop.bass
+++ b/demos/fib-tail-loop.bass
@@ -1,7 +1,7 @@
-(import (load (*dir*/fib-tail)) fib)
+(use (*dir*/fib-tail))
 
 (defn loop [fn]
   (fn)
   (loop fn))
 
-(loop (fn [] (time (fib 20))))
+(loop (fn [] (time (fib-tail:fib 20))))

--- a/demos/git-lib.bass
+++ b/demos/git-lib.bass
@@ -1,16 +1,7 @@
-; TODO: once github.com is implemented
-; (use (.git "alpine/git")
-;      (git:github.com/vito/bass/HEAD/demos/lib/images))
-
-(use (.git "alpine/git"))
-
-(def bass-src
-  (let [repo "https://github.com/vito/bass"]
-    (git:checkout repo (git:ls-remote repo "HEAD"))))
-
-(def images
-  (load (bass-src/demos/lib/images)))
+(use (.git "alpine/git")
+     (git:github/vito/tabs/ref/main/gh))
 
 (run
-  (from (images:bass bass-src)
-    ($ bass --version)))
+  (from gh:cli
+    ($ gh --version)
+    ($ ls git:github/vito/bass/ref/main/)))

--- a/demos/lib/images.bass
+++ b/demos/lib/images.bass
@@ -1,5 +1,0 @@
-; an image with bass pre-installed from the given source code path
-(defn bass [src]
-  (from "golang"
-    (cd src
-      ($ go install ./cmd/...))))

--- a/eval_test.go
+++ b/eval_test.go
@@ -281,6 +281,9 @@ func (path *dummyPath) Decode(dest interface{}) error {
 	case *bass.Value:
 		*x = path
 		return nil
+	case *bass.Combiner:
+		*x = path
+		return nil
 	case *bass.Path:
 		*x = path
 		return nil
@@ -290,6 +293,10 @@ func (path *dummyPath) Decode(dest interface{}) error {
 			Destination: dest,
 		}
 	}
+}
+
+func (path *dummyPath) Call(ctx context.Context, val bass.Value, scope *bass.Scope, cont bass.Cont) bass.ReadyCont {
+	return bass.Wrap(bass.ExtendOperative{path}).Call(ctx, val, scope, cont)
 }
 
 func (path *dummyPath) Eval(_ context.Context, _ *bass.Scope, cont bass.Cont) bass.ReadyCont {

--- a/fspath.go
+++ b/fspath.go
@@ -198,13 +198,17 @@ func (value FSPath) Eval(_ context.Context, _ *Scope, cont Cont) ReadyCont {
 var _ Applicative = ThunkPath{}
 
 func (app FSPath) Unwrap() Combiner {
-	return PathOperative{app}
+	if app.Path.File != nil {
+		return ThunkOperative{app}
+	} else {
+		return ExtendOperative{app}
+	}
 }
 
 var _ Combiner = FSPath{}
 
 func (combiner FSPath) Call(ctx context.Context, val Value, scope *Scope, cont Cont) ReadyCont {
-	return Wrap(PathOperative{combiner}).Call(ctx, val, scope, cont)
+	return Wrap(combiner.Unwrap()).Call(ctx, val, scope, cont)
 }
 
 var _ Path = FSPath{}

--- a/ground_test.go
+++ b/ground_test.go
@@ -348,10 +348,10 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 				bass.Symbol("sup"),
 				bass.CommandPath{"foo"},
 				bass.FilePath{"foo"},
+				bass.DirPath{"foo"},
 			},
 			Falses: []bass.Value{
 				bass.Keyword("sup"),
-				bass.DirPath{"foo"},
 			},
 		},
 		{
@@ -361,11 +361,11 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 				bass.Symbol("sup"),
 				bass.CommandPath{"foo"},
 				bass.FilePath{"foo"},
+				bass.DirPath{"foo"},
 			},
 			Falses: []bass.Value{
 				bass.Keyword("sup"),
 				quoteOp,
-				bass.DirPath{"foo"},
 			},
 		},
 		{

--- a/ground_test.go
+++ b/ground_test.go
@@ -1644,12 +1644,12 @@ func TestGroundPaths(t *testing.T) {
 		{
 			Name:   "subpath dir file",
 			Bass:   `(subpath ./dir/ ./file)`,
-			Result: bass.FilePath{"./dir/file"},
+			Result: bass.FilePath{"dir/file"},
 		},
 		{
 			Name:   "subpath dir dir",
 			Bass:   `(subpath ./dir/ ./sub/)`,
-			Result: bass.DirPath{"./dir/sub"},
+			Result: bass.DirPath{"dir/sub"},
 		},
 		{
 			Name: "subpath thunk dir file",
@@ -1661,7 +1661,7 @@ func TestGroundPaths(t *testing.T) {
 					},
 				},
 				Path: bass.FileOrDirPath{
-					File: &bass.FilePath{"./dir/file"},
+					File: &bass.FilePath{"dir/file"},
 				},
 			},
 		},
@@ -1747,7 +1747,7 @@ func TestBuiltinCombiners(t *testing.T) {
 			Name: "file path",
 			Bass: `(./foo "help")`,
 			Result: bass.Bindings{
-				"path":  bass.FilePath{"./foo"},
+				"path":  bass.FilePath{"foo"},
 				"stdin": bass.NewList(bass.String("help")),
 			}.Scope(),
 		},
@@ -1755,7 +1755,7 @@ func TestBuiltinCombiners(t *testing.T) {
 			Name: "file path applicative",
 			Bass: `(apply ./foo [(quote foo)])`,
 			Result: bass.Bindings{
-				"path":  bass.FilePath{"./foo"},
+				"path":  bass.FilePath{"foo"},
 				"stdin": bass.NewList(bass.Symbol("foo")),
 			}.Scope(),
 		},

--- a/host_path.go
+++ b/host_path.go
@@ -81,13 +81,17 @@ func (value HostPath) Eval(_ context.Context, _ *Scope, cont Cont) ReadyCont {
 var _ Applicative = ThunkPath{}
 
 func (app HostPath) Unwrap() Combiner {
-	return PathOperative{app}
+	if app.Path.File != nil {
+		return ThunkOperative{app}
+	} else {
+		return ExtendOperative{app}
+	}
 }
 
 var _ Combiner = HostPath{}
 
 func (combiner HostPath) Call(ctx context.Context, val Value, scope *Scope, cont Cont) ReadyCont {
-	return Wrap(PathOperative{combiner}).Call(ctx, val, scope, cont)
+	return Wrap(combiner.Unwrap()).Call(ctx, val, scope, cont)
 }
 
 var _ Path = HostPath{}

--- a/path.go
+++ b/path.go
@@ -526,7 +526,7 @@ func (value ExtendOperative) Eval(_ context.Context, _ *Scope, cont Cont) ReadyC
 }
 
 // Call constructs a thunk, passing arguments as values on stdin.
-func (op ExtendOperative) Call(ctx context.Context, val Value, scope *Scope, cont Cont) ReadyCont {
+func (op ExtendOperative) Call(_ context.Context, val Value, _ *Scope, cont Cont) ReadyCont {
 
 	var args []Value
 	if err := val.Decode(&args); err != nil {

--- a/path_test.go
+++ b/path_test.go
@@ -28,11 +28,13 @@ func TestDirPathDecode(t *testing.T) {
 
 	var comb bass.Combiner
 	err = bass.DirPath{"foo"}.Decode(&comb)
-	is.True(err != nil)
+	is.NoErr(err)
+	is.Equal(comb, bass.DirPath{"foo"})
 
 	var app bass.Applicative
-	err = bass.DirPath{"foo"}.Decode(&app)
-	is.True(err != nil)
+	err = bass.DirPath{"bar"}.Decode(&app)
+	is.NoErr(err)
+	is.Equal(app, bass.DirPath{"bar"})
 }
 
 func TestDirPathEqual(t *testing.T) {

--- a/reader.go
+++ b/reader.go
@@ -242,7 +242,7 @@ func readPath(segments []string) (Value, error) {
 	}
 
 	for i := 1; i <= end; i++ {
-		var child Path
+		var child FilesystemPath
 		if i == end && !isDir {
 			child = FilePath{
 				Path: segments[i],

--- a/runtimes/suite.go
+++ b/runtimes/suite.go
@@ -103,7 +103,7 @@ func Suite(t *testing.T, pool *Pool) {
 			File: "load.bass",
 			Result: bass.NewList(
 				bass.String("a!b!c"),
-				bass.NewList(bass.String("hello"), bass.FilePath{Path: "./goodbye"}),
+				bass.NewList(bass.String("hello"), bass.FilePath{Path: "goodbye"}),
 				bass.Bindings{"a": bass.Int(1)}.Scope(),
 				bass.Bindings{"b": bass.Int(2)}.Scope(),
 				bass.Bindings{"c": bass.Int(3)}.Scope(),
@@ -177,7 +177,7 @@ func RunTest(ctx context.Context, t *testing.T, pool *Pool, file string) (bass.V
 
 	ctx = ioctx.StderrToContext(ctx, os.Stderr)
 
-	dir, err := filepath.Abs(filepath.Dir(filepath.Join("./testdata/", file)))
+	dir, err := filepath.Abs(filepath.Dir(filepath.Join("testdata", file)))
 	is.NoErr(err)
 
 	scope := NewScope(bass.NewStandardScope(), RunState{

--- a/std/git.bass
+++ b/std/git.bass
@@ -29,3 +29,22 @@
         ($ git checkout $ref)
         ($ git submodule update --init --recursive))
       ./)))
+
+; a root path for repos on github.com
+;
+; github/vito/bass/sha/deadbeef will run return a path to github.com/vito/bass
+; checked out to commit 'deadbeef'.
+;
+; github/vito/bass/ref/main will run reference a path to github.com/vito/bass at
+; the sha that 'main' refers to.
+(defn github [user]
+  (fn [repo]
+    (let [uri (str "https://github.com/" (name user) "/" (name repo))]
+      (fn [route]
+        (case route
+          ./sha/
+          (fn [sha] (checkout uri (name sha)))
+
+          ./ref/
+          (fn [ref]
+            (checkout uri (ls-remote uri (name ref)))))))))

--- a/thunk_path.go
+++ b/thunk_path.go
@@ -14,7 +14,7 @@ type ThunkPath struct {
 var _ Value = ThunkPath{}
 
 func (value ThunkPath) String() string {
-	return fmt.Sprintf("%s/%s", value.Thunk, value.Path)
+	return fmt.Sprintf("(path %s %s)", value.Thunk, value.Path)
 }
 
 func (value ThunkPath) Equal(other Value) bool {

--- a/thunk_path.go
+++ b/thunk_path.go
@@ -77,13 +77,17 @@ func (value ThunkPath) Eval(_ context.Context, _ *Scope, cont Cont) ReadyCont {
 var _ Applicative = ThunkPath{}
 
 func (app ThunkPath) Unwrap() Combiner {
-	return PathOperative{app}
+	if app.Path.File != nil {
+		return ThunkOperative{app}
+	} else {
+		return ExtendOperative{app}
+	}
 }
 
 var _ Combiner = ThunkPath{}
 
 func (combiner ThunkPath) Call(ctx context.Context, val Value, scope *Scope, cont Cont) ReadyCont {
-	return Wrap(PathOperative{combiner}).Call(ctx, val, scope, cont)
+	return Wrap(combiner.Unwrap()).Call(ctx, val, scope, cont)
 }
 
 var _ Path = ThunkPath{}

--- a/value_test.go
+++ b/value_test.go
@@ -421,11 +421,11 @@ func TestString(t *testing.T) {
 		},
 		{
 			bass.DirPath{"foo"},
-			"foo/",
+			"./foo/",
 		},
 		{
 			bass.FilePath{"foo"},
-			"foo",
+			"./foo",
 		},
 		{
 			bass.CommandPath{"go"},
@@ -433,7 +433,7 @@ func TestString(t *testing.T) {
 		},
 		{
 			bass.FilePath{"foo"}.Unwrap(),
-			"(unwrap foo)",
+			"(unwrap ./foo)",
 		},
 		{
 			bass.CommandPath{"go"}.Unwrap(),
@@ -444,14 +444,14 @@ func TestString(t *testing.T) {
 				Parent: bass.DirPath{"foo"},
 				Child:  bass.FilePath{"bar"},
 			},
-			"foo/bar",
+			"./foo/bar",
 		},
 		{
 			bass.ExtendPath{
 				Parent: bass.DirPath{"foo"},
 				Child:  bass.DirPath{"bar"},
 			},
-			"foo/bar/",
+			"./foo/bar/",
 		},
 		{
 			bass.ThunkPath{
@@ -464,7 +464,7 @@ func TestString(t *testing.T) {
 					Dir: &bass.DirPath{"dir"},
 				},
 			},
-			"<thunk: a966bb4ef6d955500f26896319657332ae31822a>/dir/",
+			"(path <thunk: a966bb4ef6d955500f26896319657332ae31822a> ./dir/)",
 		},
 	} {
 		t.Run(fmt.Sprintf("%T", test.src), func(t *testing.T) {


### PR DESCRIPTION
closes #23 

Three features:

* Generalize paths by making `a/b/c/d` shorthand for `(((a ./b/) ./c/) ./d)`. All paths are now combiners, instead of only some of them. See 437dd716bfcb571e1dd765004f8e9348dcbf9148 for more info.
* Make paths bindable with const equality semantics so that you can compare them in `(case)`.
* Add `(github)` to the `git` stdlib, a path root for building paths to cloned repos.

Usage:

```clojure
(use (.git "alpine/git")
     (git:github/vito/booklit/ref/HEAD/project))

(run (project:test project:*root* *args*))
```