### PR TITLE
add (memo) and (unmemo), use for dependency pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ Session.vim
 
 # directory for stashing build/test-time dependencies, e.g. buildkitd, runc,
 # rootlesskit
-/hack/bin
+/hack/buildkit/bin
 
 # super secure
 /secrets*

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ cover.html
 # compiled stuff
 pkg/runtimes/shim/bin/exe.*
 /out
+
+# created by tests, don't want it committed
+pkg/runtimes/testdata/memo/bass.lock

--- a/bass.lock
+++ b/bass.lock
@@ -1,0 +1,57 @@
+{
+  "memo": {
+    "resolve-image": [
+      {
+        "input": {
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "alpine",
+          "tag": "latest"
+        },
+        "output": {
+          "digest": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "alpine",
+          "tag": "latest"
+        }
+      },
+      {
+        "input": {
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "alpine/git",
+          "tag": "latest"
+        },
+        "output": {
+          "digest": "sha256:d4740deff7f05d2d48771ff66d9d9c26dfb76f0db0aa833b1ea0ee346fa1e48f",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "alpine/git",
+          "tag": "latest"
+        }
+      },
+      {
+        "input": {
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "golang",
+          "tag": "1.17"
+        },
+        "output": {
+          "digest": "sha256:301609ebecc0ec4cd3174294220a4d9c92aab9015b3a2958297d7663aac627a1",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "golang",
+          "tag": "1.17"
+        }
+      }
+    ]
+  }
+}

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@ buildGoModule rec {
   src = ./.;
 
   # get using ./hack/get-nix-vendorsha
-  vendorSha256 = "sha256-vwzBO0e+bHxD/uO3GBbGH4QjwsZ4JONL2mPKy87bll0=";
+  vendorSha256 = "sha256-BRnuBTSO1QPW6M7S/p9jO9YJcB7ac7toMz3rBlkTiFk=";
 
   nativeBuildInputs = [ makeWrapper ];
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/containerd/containerd v1.6.0-beta.3
 	github.com/docker/distribution v2.7.1+incompatible
 	github.com/gertd/go-pluralize v0.1.7
-	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/gofrs/flock v0.8.1
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jonboulle/clockwork v0.2.2
@@ -33,7 +33,6 @@ require (
 	github.com/vito/is v0.0.5
 	github.com/vito/progrock v0.0.0-20220119041911-1bf3f68413ed
 	github.com/vito/vt100 v0.0.0-20211217051322-45a31b434dad
-	go.etcd.io/bbolt v1.3.6
 	go.uber.org/zap v1.19.1
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )

--- a/go.sum
+++ b/go.sum
@@ -1330,7 +1330,6 @@ github.com/yvasiyarov/newrelic_platform_go v0.0.0-20140908184405-b21fdbd4370f/go
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
-go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
 go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=

--- a/hack/with-deps
+++ b/hack/with-deps
@@ -19,7 +19,7 @@ pushd $(dirname $0)/..
   # checked with 'file' and 'ldd' that the shim and bass exes should have been
   # compatible. still failed.
   make clean
-  make out/bass
+  make -j out/bass
   export PATH=$PWD/out:$PATH
 popd
 

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -17,8 +17,12 @@ type FilesystemPath interface {
 	// path separators.
 	FromSlash() string
 
-	// IsDir() returns true if the path refers to a directory.
+	// IsDir returns true if the path refers to a directory.
 	IsDir() bool
+
+	// Dir returns the parent directory of the path, or the same directory if
+	// there is no parent.
+	Dir() DirPath
 }
 
 // ParseFileOrDirPath parses arg as a path using the host machine's separator
@@ -51,6 +55,24 @@ func ParseFileOrDirPath(arg string) FileOrDirPath {
 type FileOrDirPath struct {
 	File *FilePath
 	Dir  *DirPath
+}
+
+func NewFileOrDirPath(path FilesystemPath) FileOrDirPath {
+	var fp FilePath
+	if err := path.Decode(&fp); err == nil {
+		return FileOrDirPath{
+			File: &fp,
+		}
+	}
+
+	var dp DirPath
+	if err := path.Decode(&dp); err == nil {
+		return FileOrDirPath{
+			Dir: &dp,
+		}
+	}
+
+	panic(fmt.Sprintf("absurd: non-File or Dir FilesystemPath: %T", path))
 }
 
 // String calls String on whichever value is present.

--- a/pkg/bass/memo.go
+++ b/pkg/bass/memo.go
@@ -1,0 +1,330 @@
+package bass
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	"github.com/gofrs/flock"
+)
+
+// Memos is where memoized calls are cached.
+type Memos interface {
+	Store(category Symbol, input Value, output Value) error
+	Retrieve(category Symbol, input Value) (Value, bool, error)
+	Remove(category Symbol, input Value) error
+}
+
+func init() {
+	Ground.Set("memo",
+		Func("memo", "[f category]", func(f Combiner, memos Path, category Symbol) Combiner {
+			return Wrap(Op("memo", "[selector]", func(ctx context.Context, cont Cont, scope *Scope, input Value) ReadyCont {
+				memo, err := OpenMemos(ctx, memos)
+				if err != nil {
+					return cont.Call(nil, fmt.Errorf("open memos: %w", err))
+				}
+
+				res, found, err := memo.Retrieve(category, input)
+				if err != nil {
+					return cont.Call(nil, fmt.Errorf("retrieve memo %s: %w", category, err))
+				}
+
+				if found {
+					return cont.Call(res, nil)
+				}
+
+				return f.Call(ctx, NewList(input), scope, Continue(func(res Value) Value {
+					err := memo.Store(category, input, res)
+					if err != nil {
+						return cont.Call(nil, fmt.Errorf("store memo %s: %w", category, err))
+					}
+
+					return cont.Call(res, nil)
+				}))
+			}))
+		}))
+
+	Ground.Set("unmemo",
+		Func("unmemo", "[memos category filter]", func(ctx context.Context, memos Path, category Symbol, filter *Scope) error {
+			memo, err := OpenMemos(ctx, memos)
+			if err != nil {
+				return fmt.Errorf("open memos: %w", err)
+			}
+
+			return memo.Remove(category, filter)
+		}))
+}
+
+type Lockfile struct {
+	path string
+	lock *flock.Flock
+}
+
+type LockfileContent struct {
+	Data Data `json:"memo"`
+}
+
+type Data map[Symbol][]Memory
+
+type Memory struct {
+	Input  ValueJSON `json:"input"`
+	Output ValueJSON `json:"output"`
+}
+
+// ValueJSON is just an envelope for an arbitrary Value.
+type ValueJSON struct {
+	Value
+}
+
+func (res *ValueJSON) UnmarshalJSON(p []byte) error {
+	var val interface{}
+	err := UnmarshalJSON(p, &val)
+	if err != nil {
+		return err
+	}
+
+	value, err := ValueOf(val)
+	if err != nil {
+		return err
+	}
+
+	res.Value = value
+
+	return nil
+}
+
+func (res ValueJSON) MarshalJSON() ([]byte, error) {
+	return MarshalJSON(res.Value)
+}
+
+const LockfileName = "bass.lock"
+
+func OpenMemos(ctx context.Context, dir Path) (Memos, error) {
+	var hostPath HostPath
+	if err := dir.Decode(&hostPath); err == nil {
+		if hostPath.Path.FilesystemPath().IsDir() {
+			if lf, ok := searchLockfile(hostPath.FromSlash()); ok {
+				return lf, nil
+			} else {
+				return NoopMemos{}, nil
+			}
+		} else {
+			return NewLockfileMemo(hostPath.FromSlash()), nil
+		}
+	}
+
+	var thunkPath ThunkPath
+	if err := dir.Decode(&thunkPath); err == nil {
+		// TODO: read-only repository that locates via exporting and calling .Dir()
+		// until it's found (TODO: cache heavily)
+		return NoopMemos{}, nil
+	}
+
+	var fsPath FSPath
+	if err := dir.Decode(&fsPath); err == nil {
+		// NB: this is intentional; there aren't any pinned dependencies in stdlib.
+		return NoopMemos{}, nil
+	}
+
+	return nil, fmt.Errorf("cannot locate memosphere in %T: %s", dir, dir)
+}
+
+func searchLockfile(startDir string) (*Lockfile, bool) {
+	here := filepath.Join(startDir, LockfileName)
+	if _, err := os.Stat(here); err == nil {
+		return NewLockfileMemo(here), true
+	}
+
+	parent := filepath.Dir(startDir)
+	if parent == startDir {
+		// reached root
+		return nil, false
+	}
+
+	return searchLockfile(parent)
+}
+
+func NewLockfileMemo(path string) *Lockfile {
+	return &Lockfile{
+		path: path,
+		lock: flock.New(path),
+	}
+}
+
+var _ Memos = &Lockfile{}
+
+func (file *Lockfile) Store(category Symbol, input Value, output Value) error {
+	err := file.lock.Lock()
+	if err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+
+	defer file.lock.Unlock()
+
+	content, err := file.load()
+	if err != nil {
+		return fmt.Errorf("load lock file: %w", err)
+	}
+
+	entries, found := content.Data[category]
+	if !found {
+		entries = []Memory{}
+	}
+
+	var updated bool
+	for i, e := range entries {
+		if e.Input.Equal(input) {
+			entries[i].Output = ValueJSON{output}
+			updated = true
+		}
+	}
+
+	if !updated {
+		entries = append(entries, Memory{ValueJSON{input}, ValueJSON{output}})
+	}
+
+	content.Data[category] = entries
+
+	return file.save(content)
+}
+
+func (file *Lockfile) Retrieve(category Symbol, input Value) (Value, bool, error) {
+	err := file.lock.RLock()
+	if err != nil {
+		return nil, false, fmt.Errorf("lock: %w", err)
+	}
+
+	defer file.lock.Unlock()
+
+	content, err := file.load()
+	if err != nil {
+		return nil, false, fmt.Errorf("load lock file: %w", err)
+	}
+
+	entries, found := content.Data[category]
+	if !found {
+		return nil, false, nil
+	}
+
+	for _, e := range entries {
+		if e.Input.Equal(input) {
+			return e.Output, true, nil
+		}
+	}
+
+	return nil, false, nil
+}
+
+func (file *Lockfile) Remove(category Symbol, input Value) error {
+	err := file.lock.Lock()
+	if err != nil {
+		return fmt.Errorf("lock: %w", err)
+	}
+
+	defer file.lock.Unlock()
+
+	content, err := file.load()
+	if err != nil {
+		return fmt.Errorf("load lock file: %w", err)
+	}
+
+	entries, found := content.Data[category]
+	if !found {
+		return nil
+	}
+
+	kept := []Memory{}
+	for _, e := range entries {
+		// TODO: would be nice to support IsSubsetOf semantics
+		if !input.Equal(e.Input) {
+			kept = append(kept, e)
+		}
+	}
+
+	if len(kept) == 0 {
+		delete(content.Data, category)
+	} else {
+		content.Data[category] = kept
+	}
+
+	return file.save(content)
+}
+
+func (file *Lockfile) load() (*LockfileContent, error) {
+	payload, err := os.ReadFile(file.path)
+	if err != nil {
+		return nil, fmt.Errorf("read lock: %w", err)
+	}
+
+	content := LockfileContent{
+		Data: Data{},
+	}
+
+	err = UnmarshalJSON(payload, &content)
+	if err != nil {
+		var syn *json.SyntaxError
+		if errors.As(err, &syn) && syn.Error() == "unexpected end of JSON input" {
+			return &content, nil
+		}
+
+		if errors.Is(err, io.EOF) {
+			return &content, nil
+		}
+
+		return nil, fmt.Errorf("unmarshal: %w", err)
+	}
+
+	for c, es := range content.Data {
+		filtered := []Memory{}
+		for _, e := range es {
+			if e.Input.Value == nil || e.Output.Value == nil {
+				// filter any corrupt entries
+				continue
+			}
+
+			filtered = append(filtered, e)
+		}
+
+		if len(filtered) == 0 {
+			delete(content.Data, c)
+		} else {
+			content.Data[c] = filtered
+		}
+	}
+
+	return &content, nil
+}
+
+func (file *Lockfile) save(content *LockfileContent) error {
+	buf := new(bytes.Buffer)
+	enc := NewEncoder(buf)
+	enc.SetIndent("", "  ")
+
+	err := enc.Encode(content)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(file.path, buf.Bytes(), 0644)
+}
+
+type NoopMemos struct{}
+
+var _ Memos = NoopMemos{}
+
+func (NoopMemos) Store(Symbol, Value, Value) error {
+	return nil
+}
+
+func (NoopMemos) Retrieve(Symbol, Value) (Value, bool, error) {
+	return nil, false, nil
+}
+
+func (NoopMemos) Remove(Symbol, Value) error {
+	return nil
+}

--- a/pkg/bass/path.go
+++ b/pkg/bass/path.go
@@ -138,6 +138,10 @@ func (value DirPath) FromSlash() string {
 	}
 }
 
+func (value DirPath) Dir() DirPath {
+	return DirPath{path.Dir(value.Path)}
+}
+
 func (value DirPath) IsDir() bool {
 	return true
 }

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -158,6 +158,20 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 				bass.String("HI! <- hi!"),
 			),
 		},
+		{
+			File: "memo/thunk.bass",
+			Result: bass.NewList(
+				bass.String("SUB COMMITTED! <- sub committed!"),
+				bass.String("HEY! <- hey!"),
+				bass.String("SUB COMMITTED! <- sub committed!"),
+				bass.String("HEY! <- hey!"),
+				bass.String("PARENT COMMITTED! <- parent committed!"),
+				bass.String("HEY! <- hey!"),
+				bass.String("HEY! <- sub committed!"),
+				bass.String("HEY! <- parent committed!"),
+				bass.String("HEY! <- hey!"),
+			),
+		},
 	} {
 		test := test
 		t.Run(filepath.Base(test.File), func(t *testing.T) {

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -150,6 +150,14 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 				bass.Int(10),
 			),
 		},
+		{
+			File: "memo/peer.bass",
+			Result: bass.NewList(
+				bass.String("HEY! <- hey!"),
+				bass.String("HEY! <- hey!"),
+				bass.String("HI! <- hi!"),
+			),
+		},
 	} {
 		test := test
 		t.Run(filepath.Base(test.File), func(t *testing.T) {

--- a/pkg/runtimes/testdata/memo/peer.bass
+++ b/pkg/runtimes/testdata/memo/peer.bass
@@ -1,0 +1,17 @@
+(def hey-shouts
+  (load (-> (*dir*/sub/shout *dir*)
+            (with-env {:SHOUT_PREFIX "HEY! "}))))
+
+(def hi-shouts
+  (load (-> (*dir*/sub/shout *dir*)
+            (with-env {:SHOUT_PREFIX "HI! "}))))
+
+(def hey-shout
+  (hey-shouts:memo-shout *dir*/bass.lock))
+
+(def hi-shout
+  (hi-shouts:memo-shout *dir*/bass.lock))
+
+[(hey-shout "<- hey")
+ (hi-shout "<- hey")
+ (hi-shout "<- hi")]

--- a/pkg/runtimes/testdata/memo/peer.bass
+++ b/pkg/runtimes/testdata/memo/peer.bass
@@ -1,9 +1,9 @@
 (def hey-shouts
-  (load (-> (*dir*/sub/shout *dir*)
+  (load (-> (*dir*/sub/shout)
             (with-env {:SHOUT_PREFIX "HEY! "}))))
 
 (def hi-shouts
-  (load (-> (*dir*/sub/shout *dir*)
+  (load (-> (*dir*/sub/shout)
             (with-env {:SHOUT_PREFIX "HI! "}))))
 
 (def hey-shout

--- a/pkg/runtimes/testdata/memo/sub/parent-bass.lock
+++ b/pkg/runtimes/testdata/memo/sub/parent-bass.lock
@@ -1,0 +1,10 @@
+{
+  "memo": {
+    "some-category": [
+      {
+        "input": "<- parent committed",
+        "output": "PARENT COMMITTED! <- parent committed!"
+      }
+    ]
+  }
+}

--- a/pkg/runtimes/testdata/memo/sub/shout.bass
+++ b/pkg/runtimes/testdata/memo/sub/shout.bass
@@ -1,0 +1,5 @@
+(defn shout [x]
+  (str *env*:SHOUT_PREFIX x "!"))
+
+(defn memo-shout [memos]
+  (memo shout memos :some-category))

--- a/pkg/runtimes/testdata/memo/sub/sub-bass.lock
+++ b/pkg/runtimes/testdata/memo/sub/sub-bass.lock
@@ -1,0 +1,10 @@
+{
+  "memo": {
+    "some-category": [
+      {
+        "input": "<- sub committed",
+        "output": "SUB COMMITTED! <- sub committed!"
+      }
+    ]
+  }
+}

--- a/pkg/runtimes/testdata/memo/thunk.bass
+++ b/pkg/runtimes/testdata/memo/thunk.bass
@@ -1,0 +1,38 @@
+(def hey-shouts
+  (load (-> (*dir*/sub/shout)
+            (with-env {:SHOUT_PREFIX "HEY! "}))))
+
+(def cp-thunk
+  (from (linux/alpine)
+    ($ cp -a *dir*/sub/ ./sub/)))
+
+(def sub-thunk
+  (from cp-thunk
+    ($ mv ./sub/sub-bass.lock ./sub/bass.lock)))
+
+(def parent-thunk
+  (from cp-thunk
+    ($ mv ./sub/parent-bass.lock ./bass.lock)))
+
+(def no-shout
+  ; this should not be able to find a bass.lock
+  (hey-shouts:memo-shout cp-thunk/sub/))
+
+(def cp-shout
+  (hey-shouts:memo-shout cp-thunk/sub/sub-bass.lock))
+
+(def sub-shout
+  (hey-shouts:memo-shout sub-thunk/sub/))
+
+(def parent-shout
+  (hey-shouts:memo-shout parent-thunk/sub/))
+
+[(cp-shout "<- sub committed")
+ (cp-shout "<- hey")
+ (sub-shout "<- sub committed")
+ (sub-shout "<- hey")
+ (parent-shout "<- parent committed")
+ (parent-shout "<- hey")
+ (no-shout "<- sub committed") ; will actually be HEY!
+ (no-shout "<- parent committed") ; will actually be HEY!
+ (no-shout "<- hey")]

--- a/project.bass
+++ b/project.bass
@@ -1,20 +1,12 @@
 (use (.git (linux/alpine/git)))
 
-; url of the git repository
-(def url
-  "https://github.com/vito/bass")
-
-; root of the local checkout of the git repository
+; root of the git repository
 (def *root*
   *dir*)
 
-; resolves a ref to a sha
-(defn resolve-ref [ref]
-  (git:ls-remote url ref))
-
 ; clones the repo and checks out the given sha
 (defn checkout [sha]
-  (git:checkout url sha))
+  (git:github/vito/bass/sha/ sha))
 
 (provide [build]
   ; runs a quick sanity check

--- a/std/git.bass
+++ b/std/git.bass
@@ -37,21 +37,45 @@
         ($ git submodule update --init --recursive))
       ./)))
 
-; a root path for repos on github.com
+(provide [path]
+  (defn memo-ls-remote [memos uri ref]
+    ((memo (fn [sel] (ls-remote sel:uri sel:ref)) memos :git-ls-remote)
+     {:uri uri :ref ref}))
+
+  (defn seg [path-or-str]
+    (if (string? path-or-str)
+      path-or-str
+      (path-name path-or-str)))
+
+  ; returns a path root for repos at the given base URL
+  ;
+  ; Please omit the trailing slash. (TODO: would be nice to just strip it or
+  ; somehow make it a non-issue.)
+  ;
+  ; => (use (.git (linux/alpine/git)))
+  (defn path [memos url]
+    (fn [user]
+      (fn [repo]
+        (let [uri (str url "/" (seg user) "/" (seg repo))]
+          (fn [route]
+            (case route
+              ./sha/
+              (fn [sha] (checkout uri (seg sha)))
+
+              ./ref/
+              (fn [ref]
+                (checkout uri (memo-ls-remote memos uri (seg ref)))))))))))
+
+; a path root for repos hosted at github.com
+;
+; Memoizes ref resolution into the nearest bass.lock to the caller's *dir*.
 ;
 ; => (use (.git (linux/alpine/git)))
 ;
 ; => git:github/vito/bass/sha/ea8cae6d4c871cb14448d7254843d86dbab8505f/
 ;
+; => (git:github/vito/bass/sha/ "ea8cae6d4c871cb14448d7254843d86dbab8505f")
+;
 ; => git:github/vito/bass/ref/main/
-(defn github [user]
-  (fn [repo]
-    (let [uri (str "https://github.com/" (path-name user) "/" (path-name repo))]
-      (fn [route]
-        (case route
-          ./sha/
-          (fn [sha] (checkout uri (path-name sha)))
-
-          ./ref/
-          (fn [ref]
-            (checkout uri (ls-remote uri (path-name ref)))))))))
+(defop github args scope
+  (eval [(path scope:*dir* "https://github.com") & args] scope))

--- a/std/run.bass
+++ b/std/run.bass
@@ -49,38 +49,6 @@
           as (resolve-args args scope)]
       (apply with-args [(c) & as]))))
 
-(provide [linux]
-  (defn resolver [platform sofar]
-    (fn optional
-      (case optional
-        []
-        (resolve {:platform platform
-                  :repository sofar
-                  :tag "latest"})
-
-        [tag-or-path]
-        (cond
-          (or (symbol? tag-or-path) (string? tag-or-path))
-          (resolve {:platform platform
-                    :repository sofar
-                    :tag (str tag-or-path)})
-
-          (path? tag-or-path)
-          (resolver platform (str sofar "/" (path-name tag-or-path)))
-
-          true
-          (errorf "invalid image path segment: %s" tag-or-path)))))
-
-  ; linux is a path root for images usable by Linux runtimes
-  ;
-  ; => (linux/ubuntu)
-  ;
-  ; => (linux/ubuntu :18.04)
-  ;
-  ; => (linux/docker.io/library/ubuntu :18.04)
-  (defn linux [ref]
-    (resolver {:os "linux"} (path-name ref))))
-
 ; chain a sequence of thunks starting from an initial image
 ;
 ; => (from (linux/alpine) ($ echo "Hello, world!"))
@@ -99,3 +67,66 @@
 ^:indent
 (defn cd [dir & thunks]
   (apply from (map (fn [thunk] (with-dir thunk dir)) thunks)))
+
+(provide [path linux]
+  (defn memo-resolve [memos]
+    (if (null? memos)
+      resolve
+      (memo resolve memos :resolve-image)))
+
+  (defn join [delim strs]
+    (case strs
+      [] ""
+      [s] s
+      [s & ss] (str s delim (join delim ss))))
+
+  (defn path-resolver [do-resolve platform names]
+    (fn optional
+      (case optional
+        []
+        (do-resolve
+          {:platform platform
+           :repository (join "/" names)
+           :tag "latest"})
+
+        [tag-or-path]
+        (cond
+          (or (symbol? tag-or-path) (string? tag-or-path))
+          (do-resolve
+            {:platform platform
+             :repository (join "/" names)
+             :tag (str tag-or-path)})
+
+          (path? tag-or-path)
+          (path-resolver do-resolve
+                         platform
+                         (conj names (path-name tag-or-path)))
+
+          true
+          (errorf "invalid image path segment: %s" tag-or-path)))))
+
+  ; returns a path root for resolving images with the given platform
+  ;
+  ; Memoizes image resolution into memos.
+  ;
+  ; => (def linux (path {:os "linux"}))
+  ;
+  ; => (linux/ubuntu)
+  ;
+  ; => (linux/ubuntu :18.04)
+  ;
+  ; => (linux/docker.io/library/ubuntu :18.04)
+  (defn path [memos platform]
+    (path-resolver (memo-resolve memos) platform []))
+
+  ; a path root for resolving Linux images
+  ;
+  ; Memoizes image resolution into the nearest bass.lock to the caller's *dir*.
+  ;
+  ; => (linux/ubuntu)
+  ;
+  ; => (linux/ubuntu :18.04)
+  ;
+  ; => (linux/docker.io/library/ubuntu :18.04)
+  (defop linux args scope
+    (eval [(path scope:*dir* {:os "linux"}) & args] scope)))


### PR DESCRIPTION
this seems to be enough for an MVP of version pinning. i have no idea if this will be the long-term plan.

fixes #46 

`(memo)` memoizes a function, storing categorized input/outputs in the given path. if the path is a dir, it will be traversed upward until a bass.lock is found. if the path is a file, it'll be used directly and created if it doesn't exist.

`(unmemo)` lets you forget. it takes the memos path, a category, and an input, and removes the input's memoized output. filtering or clearing categories can be added in the future.

with these two added...:

* `linux` now memoizes by locating the nearest bass.lock to the caller's `*dir*`. refs.db is no more, and buildkit runtime no longer has to implement caching!
* `git:github` does the same - now you can efficiently point to tags, or even dynamic branches, and have stable dependencies.

relying on the caller's `*dir*` is kind of sneaky, but it really helps with bootstrapping, since these are the two first things any bass script is likely to do, and I really don't want to have to explicitly initialize them with a `bass.lock' all the time.

TODO:

* [x] support reading bass.lock from within a thunk path (e.g. a fetched bass lib)

bonus:

* git paths now support taking strings in addition to paths, so checkout can be implemented like `(git:github/vito/bass sha)`. pretty slick!