### PR TITLE
in-memory file trees, with-dir/with-args take list, add (json)

### DIFF
--- a/ci/shipit
+++ b/ci/shipit
@@ -5,29 +5,40 @@
      (git:github/vito/tabs/ref/main/gh/release)
      (*dir*/../project))
 
-(defn parse-args [args]
-  (case args
-    ; default 3rd arg (title) to tag
-    [sha tag] [sha tag tag]
+; returns the sha256sum output of each file
+;
+; Takes care to mount each file in to the working directory so that the output
+; can be passed to sha256sum --check [--ignore-missing].
+(defn sha256sums [files]
+  (-> (from (linux/ubuntu)
+        (foldl
+          (fn [t f] (with-mount t f (path-base f)))
+          (with-args (.sha256sum) (map path-base files))
+          files))
+      (read :raw)
+      next))
 
-    ; let it fail at pattern-match time
-    _ args))
-
-(defn main args
-  (def *github-token*
-    (mask *env*:GITHUB_TOKEN :github-token))
-
+; builds and publishes a GitHub release
+;
+; Needs the sha to tag, a tag name, and a title for the release.
+(defn main [sha tag title]
   (def bass-release
-    (release:auth "vito/bass" *github-token*))
+    (release:auth "vito/bass"
+                  (mask *env*:GITHUB_TOKEN :github-token)))
 
-  (let [[sha   ; git sha to tag
-         tag   ; tag name to create
-         title ; name for the release
-         ] (parse-args args)
-        src (project:checkout sha)
-        assets [(project:build src "linux" "amd64")
-                (project:build src "darwin" "amd64")
-                (project:build src "darwin" "arm64")]]
+  (let [src (project:checkout sha)
+        ; TODO: i tried to golf this but it's honestly more readable this way
+        bins {:linux {:amd64 (project:build src "linux" "amd64")}
+              :darwin {:amd64 (project:build src "darwin" "amd64")
+                       :arm64 (project:build src "darwin" "arm64")}}
+        files [bins:linux:amd64
+               bins:darwin:amd64
+               bins:darwin:arm64
+               (mkfile ./bass.linux-amd64.json (json bins:linux:amd64))
+               (mkfile ./bass.darwin-amd64.json (json bins:darwin:amd64))
+               (mkfile ./bass.darwin-arm64.json (json bins:darwin:arm64))]
+        sums.txt (mkfile ./sha256sums.txt (sha256sums files))
+        assets (conj files sums.txt)]
   (logf "publishing bass @ %s to tag %s" sha tag)
   (log
     (bass-release:create!

--- a/demos/fs.go
+++ b/demos/fs.go
@@ -4,3 +4,6 @@ import "embed"
 
 //go:embed *
 var FS embed.FS
+
+// FSID is the ID stamped on FSPaths using the FS above.
+const FSID = "demos"

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -123,7 +123,7 @@ func (plugin *Plugin) Demo(demoFn string) (booklit.Content, error) {
 
 	stdoutSink := bass.NewInMemorySink()
 	scope := runtimes.NewScope(bass.Ground, runtimes.RunState{
-		Dir:    bass.NewFSDir(demos.FS),
+		Dir:    bass.NewFSDir(demos.FSID, demos.FS),
 		Stdout: bass.NewSink(stdoutSink),
 		Stdin:  bass.NewSource(bass.NewInMemorySource()),
 	})

--- a/docs/lit/guide.lit
+++ b/docs/lit/guide.lit
@@ -224,7 +224,7 @@ for common tasks. If you'd like to learn the language, see \reference{bassics}.
       (def meowed
         (from (linux/alpine)
           (-> ($ sh -c "cat > ./file")
-              (with-stdin "hello" "goodbye"))))
+              (with-stdin ["hello" "goodbye"]))))
 
       meowed/file
     }}}{

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -160,23 +160,27 @@ func (path *FileOrDirPath) FromValue(val Value) error {
 // be marshalable just to support .SHA1, .SHA256, .Avatar, etc. on a Thunk
 // that embeds it.
 type FSPath struct {
-	FS   fs.FS         `json:"fs"`
+	ID   string        `json:"fs"`
+	FS   fs.FS         `json:"-"`
 	Path FileOrDirPath `json:"path"`
 }
 
-func NewFSDir(fs fs.FS) FSPath {
+func NewFSDir(id string, fs fs.FS) FSPath {
+	return NewFSPath(id, fs, ParseFileOrDirPath("."))
+}
+
+func NewFSPath(id string, fs fs.FS, path FileOrDirPath) FSPath {
 	return FSPath{
-		FS: fs,
-		Path: FileOrDirPath{
-			Dir: &DirPath{"."},
-		},
+		ID:   id,
+		FS:   fs,
+		Path: path,
 	}
 }
 
 var _ Value = FSPath{}
 
 func (value FSPath) String() string {
-	return fmt.Sprintf("(fs)/%s", strings.TrimPrefix(value.Path.String(), "./"))
+	return fmt.Sprintf("<fs: %s>/%s", value.ID, strings.TrimPrefix(value.Path.String(), "./"))
 }
 
 func (value FSPath) Equal(other Value) bool {

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -71,6 +71,12 @@ func init() {
 		`Returns the given value.`,
 		`=> (dump {:foo-bar "baz"})`)
 
+	Ground.Set("mkfs",
+		Func("mkfs", "file-content-kv", NewInMemoryFSDir),
+		`returns a dir path backed by an in-memory filesystem`,
+		`Takes alternating file paths and their content, which must be a text string.`,
+	)
+
 	Ground.Set("log",
 		Func("log", "[val]", func(ctx context.Context, v Value) Value {
 			var msg string

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -77,6 +77,18 @@ func init() {
 		`Takes alternating file paths and their content, which must be a text string.`,
 	)
 
+	Ground.Set("json",
+		Func("json", "[val]", func(ctx context.Context, val Value) (string, error) {
+			payload, err := MarshalJSON(val)
+			if err != nil {
+				return "", err
+			}
+
+			return string(payload), nil
+		}),
+		`returns a string containing val encoded as JSON`,
+		`=> (json {:foo-bar "baz"})`)
+
 	Ground.Set("log",
 		Func("log", "[val]", func(ctx context.Context, v Value) Value {
 			var msg string

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -622,14 +622,14 @@ func init() {
 		`=> (cd ./src/ (.tests))`)
 
 	Ground.Set("with-args",
-		Func("with-args", "[thunk & vals]", (Thunk).WithArgs),
+		Func("with-args", "[thunk args]", (Thunk).WithArgs),
 		`returns thunk with args set to args`,
-		`=> (with-args (.go) "test" "./...")`)
+		`=> (with-args (.go) ["test" "./..."])`)
 
 	Ground.Set("with-stdin",
-		Func("with-stdin", "[thunk & vals]", (Thunk).WithStdin),
+		Func("with-stdin", "[thunk vals]", (Thunk).WithStdin),
 		`returns thunk with stdin set to vals`,
-		`=> (with-stdin ($ jq ".a") {:a 1} {:a 2})`)
+		`=> (with-stdin ($ jq ".a") [{:a 1} {:a 2}])`)
 
 	Ground.Set("with-env",
 		Func("with-env", "[thunk env]", (Thunk).WithEnv),

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -1645,6 +1645,11 @@ func TestGroundStrings(t *testing.T) {
 			Bass:   "(trim \" \n\tfoo\n\t \")",
 			Result: bass.String("foo"),
 		},
+		{
+			Name:   "json",
+			Bass:   `(json {:a 1 :b true :multi-word "hello world!\n"})`,
+			Result: bass.String(`{"a":1,"b":true,"multi_word":"hello world!\n"}`),
+		},
 	} {
 		t.Run(example.Name, example.Run)
 	}

--- a/pkg/bass/json.go
+++ b/pkg/bass/json.go
@@ -30,5 +30,5 @@ func MarshalJSON(val interface{}) ([]byte, error) {
 		return nil, err
 	}
 
-	return buf.Bytes(), nil
+	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
 }

--- a/pkg/bass/memfs.go
+++ b/pkg/bass/memfs.go
@@ -1,0 +1,141 @@
+package bass
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"path"
+	"sort"
+	"time"
+)
+
+// NewInMemoryFSDir is exposed as (mkfs) - it takes alternating file paths and
+// content and constructs an in-memory filesystem path.
+func NewInMemoryFSDir(fileContentPairs ...Value) (FSPath, error) {
+	if len(fileContentPairs)%2 != 0 {
+		return FSPath{}, fmt.Errorf("mkfs: %w: odd pairing", ErrBadSyntax)
+	}
+
+	memfs := InMemoryFS{}
+	var file FilePath
+	for i, val := range fileContentPairs {
+		if i%2 == 0 {
+			// path
+			if err := val.Decode(&file); err != nil {
+				return FSPath{}, fmt.Errorf("arg %d: %w", i+1, err)
+			}
+		} else {
+			var content string
+			if err := val.Decode(&content); err != nil {
+				return FSPath{}, fmt.Errorf("arg %d: %w", i+1, err)
+			}
+
+			memfs[path.Clean(file.String())] = content
+		}
+	}
+
+	id, err := memfs.SHA256()
+	if err != nil {
+		return FSPath{}, err
+	}
+
+	return NewFSPath(id, memfs, FileOrDirPath{Dir: &DirPath{"."}}), nil
+}
+
+// InMemoryFS is a stupid simple filesystem representation, not even concerning
+// itself with pesky permissions and timestamps.
+//
+// It maps cleaned file paths to their content. It does not contain empty
+// directories, but its file paths may be nested.
+type InMemoryFS map[string]string
+
+// SHA256 returns a checksum of the filesystem.
+func (inmem InMemoryFS) SHA256() (string, error) {
+	idSum := sha256.New()
+
+	sorted := []string{}
+	for f := range inmem {
+		sorted = append(sorted, f)
+	}
+	sort.Strings(sorted)
+
+	for _, file := range sorted {
+		if _, err := idSum.Write([]byte(file)); err != nil {
+			return "", err
+		}
+
+		content := inmem[file]
+		if _, err := idSum.Write([]byte(content)); err != nil {
+			return "", err
+		}
+	}
+
+	return fmt.Sprintf("%x", idSum.Sum(nil)), nil
+}
+
+// Opens returns a file for reading the given file's content or errors if the
+// file does not exist.
+//
+// The returned file always has 0644 permissions and a zero (Unix epoch) mtime.
+func (inmem InMemoryFS) Open(name string) (fs.File, error) {
+	content, found := inmem[name]
+	if !found {
+		return nil, &fs.PathError{Op: "open", Path: name, Err: fs.ErrNotExist}
+	}
+
+	return &inMemoryFile{
+		name: name,
+
+		Buffer: bytes.NewBufferString(content),
+	}, nil
+}
+
+type inMemoryFile struct {
+	name string
+	size int64
+
+	*bytes.Buffer
+}
+
+func (file *inMemoryFile) Stat() (fs.FileInfo, error) {
+	return &inMemoryInfo{
+		name: path.Base(file.name),
+		size: file.size,
+		mode: 0644,
+	}, nil
+}
+
+func (file *inMemoryFile) Close() error {
+	return nil
+}
+
+type inMemoryInfo struct {
+	name string
+	size int64
+	mode fs.FileMode
+}
+
+func (info *inMemoryInfo) Name() string {
+	return info.name
+}
+
+func (info *inMemoryInfo) Size() int64 {
+	return info.size
+}
+
+func (info *inMemoryInfo) ModTime() time.Time {
+	return time.Time{}
+}
+
+func (info *inMemoryInfo) Mode() fs.FileMode {
+	return info.mode
+}
+
+func (info *inMemoryInfo) IsDir() bool {
+	return false
+}
+
+func (info *inMemoryInfo) Sys() interface{} {
+	return nil
+}

--- a/pkg/bass/secret_test.go
+++ b/pkg/bass/secret_test.go
@@ -29,7 +29,7 @@ func TestSecretJSON(t *testing.T) {
 
 	payload, err := bass.MarshalJSON(secret)
 	is.NoErr(err)
-	is.Equal(string(payload), `{"secret":"token"}`+"\n")
+	is.Equal(string(payload), `{"secret":"token"}`)
 
 	var unmarshaled bass.Secret
 	err = bass.UnmarshalJSON(payload, &unmarshaled)

--- a/pkg/bass/stdlib.go
+++ b/pkg/bass/stdlib.go
@@ -17,6 +17,7 @@ func init() {
 		"lists.bass",
 		"streams.bass",
 		"run.bass",
+		"paths.bass",
 		"bool.bass",
 	} {
 		file, err := std.FS.Open(lib)

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -153,7 +153,7 @@ func (thunk Thunk) WithImage(image ThunkImage) Thunk {
 }
 
 // WithArgs sets the thunk's arg values.
-func (thunk Thunk) WithArgs(args ...Value) Thunk {
+func (thunk Thunk) WithArgs(args []Value) Thunk {
 	thunk.Args = args
 	return thunk
 }
@@ -165,7 +165,7 @@ func (thunk Thunk) WithEnv(env *Scope) Thunk {
 }
 
 // WithStdin sets the thunk's stdin values.
-func (thunk Thunk) WithStdin(stdin ...Value) Thunk {
+func (thunk Thunk) WithStdin(stdin []Value) Thunk {
 	thunk.Stdin = stdin
 	return thunk
 }

--- a/pkg/bass/thunk_types.go
+++ b/pkg/bass/thunk_types.go
@@ -63,6 +63,7 @@ func (platform Platform) CanSelect(given Platform) bool {
 type ThunkMountSource struct {
 	ThunkPath *ThunkPath
 	HostPath  *HostPath
+	FSPath    *FSPath
 	Cache     *FileOrDirPath
 	Secret    *Secret
 }
@@ -71,7 +72,10 @@ var _ Decodable = &ThunkMountSource{}
 var _ Encodable = ThunkMountSource{}
 
 func (enum ThunkMountSource) ToValue() Value {
-	if enum.HostPath != nil {
+	if enum.FSPath != nil {
+		val, _ := ValueOf(*enum.FSPath)
+		return val
+	} else if enum.HostPath != nil {
 		val, _ := ValueOf(*enum.HostPath)
 		return val
 	} else if enum.Cache != nil {
@@ -102,6 +106,12 @@ func (enum *ThunkMountSource) FromValue(val Value) error {
 	var host HostPath
 	if err := val.Decode(&host); err == nil {
 		enum.HostPath = &host
+		return nil
+	}
+
+	var fs FSPath
+	if err := val.Decode(&fs); err == nil {
+		enum.FSPath = &fs
 		return nil
 	}
 

--- a/pkg/runtimes/bass.go
+++ b/pkg/runtimes/bass.go
@@ -87,7 +87,7 @@ func (runtime *Bass) run(ctx context.Context, thunk bass.Thunk, ext string) (*ba
 
 	if thunk.Cmd.Cmd != nil {
 		cp := thunk.Cmd.Cmd
-		state.Dir = bass.NewFSDir(std.FS)
+		state.Dir = bass.NewFSDir(std.FSID, std.FS)
 
 		module = NewScope(bass.NewEmptyScope(bass.NewStandardScope(), internal.Scope), state)
 
@@ -131,7 +131,7 @@ func (runtime *Bass) run(ctx context.Context, thunk bass.Thunk, ext string) (*ba
 			Path:  fp.FileOrDir(),
 		})
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("export thunk src: %w", err)
 		}
 
 		tr := tar.NewReader(src)
@@ -150,6 +150,7 @@ func (runtime *Bass) run(ctx context.Context, thunk bass.Thunk, ext string) (*ba
 
 		dir := fsp.Path.File.Dir()
 		state.Dir = bass.FSPath{
+			ID:   fsp.ID,
 			FS:   fsp.FS,
 			Path: bass.FileOrDirPath{Dir: &dir},
 		}

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -120,6 +120,10 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 			Result: bass.NewList(bass.Int(1), bass.Int(2), bass.Int(3)),
 		},
 		{
+			File:   "fs-paths.bass",
+			Result: bass.NewList(bass.Int(1), bass.Int(2), bass.Int(3)),
+		},
+		{
 			File:   "host-paths-sparse.bass",
 			Result: bass.NewList(bass.Int(1), bass.Int(2), bass.Int(3), bass.Int(3)),
 		},

--- a/pkg/runtimes/testdata/fs-paths.bass
+++ b/pkg/runtimes/testdata/fs-paths.bass
@@ -1,0 +1,13 @@
+(def fs
+  (mkfs ./foo "1\n"
+        ./bar/baz "2\n"
+        ./fizz/buzz "3\n"))
+
+(def cat
+  (from (linux/alpine)
+    ($ cat fs/foo fs/bar/baz fs/fizz/buzz)))
+
+(let [stream (read cat :json)]
+  [(next stream)
+   (next stream)
+   (next stream)])

--- a/pkg/runtimes/testdata/response-file.bass
+++ b/pkg/runtimes/testdata/response-file.bass
@@ -3,7 +3,7 @@
 
 (def create-file
   (-> ($ sh -c "cat > response.json")
-      (with-stdin & values)
+      (with-stdin values)
       (with-image (linux/alpine))))
 
 (def response

--- a/std/fs.go
+++ b/std/fs.go
@@ -4,3 +4,6 @@ import "embed"
 
 //go:embed *.bass
 var FS embed.FS
+
+// FSID is the ID stamped on FSPaths using the FS above.
+const FSID = "std"

--- a/std/paths.bass
+++ b/std/paths.bass
@@ -1,0 +1,7 @@
+; returns an in-memory file with the given content
+(defn mkfile [name content]
+  (subpath (mkdir name content) name))
+
+; returns the path-name converted into a file path
+(defn path-base [path]
+  (string->fs-path (path-name path)))

--- a/std/run.bass
+++ b/std/run.bass
@@ -47,7 +47,7 @@
   (defop $ [cmd & args] scope
     (let [c (resolve-cmd cmd scope)
           as (resolve-args args scope)]
-      (apply with-args [(c) & as]))))
+      (with-args (c) as))))
 
 ; chain a sequence of thunks starting from an initial image
 ;


### PR DESCRIPTION
* **breaking**: `(with-args)` and `(with-stdin)` now take a single list arg instead of a variadic args. These are usually used to programmatically build a thunk, so their values tend to *not* be in the literal form that they previously were most easily used with.

    ```clojure
    (with-args (.cp) (conj files ./destination/))
    (with-stdin (.cat) (vals foo))
    ```

* add `(mkfs)`, for constructing an in-memory filesystem path:

    ```clojure
    (def fs
      (mkfs ./a "1" ./since/day "one"))

    (run (from (linux/alpine) ($ cat fs/a fs/since/day)))
    ```

    Useful for passing simple string values to a thunk as a file, e.g. for publishing checksums in a GitHub release.

* add `(mkfile)`, which defined in terms of it:

    ```clojure
    (run (from (linux/alpine) ($ ls -al (mkfile ./foo "hello")))
    ```

* add `(json)`, for JSON encoding a value (e.g. a thunk or thunk path).

    ```clojure
    (log (json "hello, world!"))
    ```