### PR TITLE
support oci layout directories

### DIFF
--- a/demos/example.nix
+++ b/demos/example.nix
@@ -1,10 +1,13 @@
-{ pkgs ? import <nixpkgs> { } }:
+{ pkgs ? import <nixpkgs> { }
+, format ? "oci"
+}:
 let
   image = pkgs.dockerTools.streamLayeredImage {
     name = "example";
     contents = [
       pkgs.coreutils
       pkgs.hello
+      pkgs.git
     ];
     config = {
       Env = [ "FOO=1" ];
@@ -15,5 +18,5 @@ pkgs.runCommand "convert-to-oci"
 {
   nativeBuildInputs = [ pkgs.skopeo ];
 } ''
-  ${image} | gzip --fast | skopeo --insecure-policy copy --quiet docker-archive:/dev/stdin oci-archive:$out:latest
+  ${image} | gzip --fast | skopeo --insecure-policy copy --quiet docker-archive:/dev/stdin ${format}:$out:latest
 ''

--- a/demos/nix.bass
+++ b/demos/nix.bass
@@ -1,13 +1,31 @@
-(def example
+(use (.time))
+
+(defn example [format]
   (subpath
     (from (linux/nixos/nix)
-      ($ nix-build *dir*/example.nix)
-      ($ cp ./result ./image.tar))
-    ./image.tar))
+      (-> ($ nix-build *dir*/example.nix --arg format (str "\"" format "\""))
+          (with-label :at (now 0))) ; bust cache
+      ; NB: technically this is either a file or a dir depending on the format
+      ($ sh -c "cp -a $(readlink result) ./image"))
+    ./image))
 
-(run
-  (from {:platform {:os "linux"}
-         :oci-archive example
-         :tag "latest"}
-    ($ env)
-    ($ hello)))
+(defop loop forms scp
+  (eval [do & forms] scp)
+  (eval [loop & forms] scp))
+
+(loop
+  (time:measure
+    (run
+      (from {:oci-archive (example "oci")
+             :platform {:os "linux"}
+             :tag "latest"}
+        ($ env)
+        ($ hello))))
+
+  (time:measure
+    (run
+      (from {:oci-archive (example "oci-archive")
+             :platform {:os "linux"}
+             :tag "latest"}
+        ($ env)
+        ($ hello)))))

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -531,23 +531,23 @@ func (b *builder) unpackImageArchive(ctx context.Context, thunkPath bass.ThunkPa
 	configSt := llb.Scratch().Run(
 		llb.AddMount("/shim", shimExe, llb.SourcePath("run")),
 		llb.AddMount(
-			"/image.tar",
+			"/image",
 			thunkSt.GetMount(workDir),
 			llb.SourcePath(thunkPath.Path.FilesystemPath().FromSlash()),
 		),
 		llb.AddMount("/config", llb.Scratch()),
-		llb.Args([]string{"/shim", "get-config", "/image.tar", tag, "/config"}),
+		llb.Args([]string{"/shim", "get-config", "/image", tag, "/config"}),
 	)
 
 	unpackSt := llb.Scratch().Run(
 		llb.AddMount("/shim", shimExe, llb.SourcePath("run")),
 		llb.AddMount(
-			"/image.tar",
+			"/image",
 			thunkSt.GetMount(workDir),
 			llb.SourcePath(thunkPath.Path.FilesystemPath().FromSlash()),
 		),
 		llb.AddMount("/rootfs", llb.Scratch()),
-		llb.Args([]string{"/shim", "unpack", "/image.tar", tag, "/rootfs"}),
+		llb.Args([]string{"/shim", "unpack", "/image", tag, "/rootfs"}),
 	)
 
 	image := unpackSt.GetMount("/rootfs")


### PR DESCRIPTION
this avoids packing a .tar archive and having to read blobs from it, but it turns out that doesn't seem to be adding that much overhead, so I'm gonna PR this for posterity but then just close the PR.

passing around a single .tar file is generally easier than passing around a layout directory.

comparison in a loop:

```
1: [17.8s] 11:47:39.720 debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.767252439s
1: [35.7s] 11:47:57.678 debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.95719406s
1: [53.9s] 11:48:15.837 debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.159464858s
1: [72.3s] 11:48:34.295 debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.457678966s
1: [91.7s] 11:48:53.603 debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 19.308019253s
1: [110.3s] 11:49:12.231        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.627630714s
1: [128.2s] 11:49:30.131        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.89968964s
1: [146.4s] 11:49:48.341        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.209790131s
1: [164.6s] 11:50:06.587        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.245904901s
1: [183.3s] 11:50:25.203        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.616274081s
1: [201.2s] 11:50:43.170        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.966878218s
1: [219.6s] 11:51:01.502        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.331373715s
1: [237.7s] 11:51:19.661        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.158843707s
1: [256.0s] 11:51:37.946        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.285064043s
1: [274.3s] 11:51:56.201        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.254677888s
1: [294.0s] 11:52:15.943        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 19.742558155s
1: [311.9s] 11:52:33.843        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.899333912s
1: [331.9s] 11:52:53.837        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 19.993889724s
1: [350.3s] 11:53:12.240        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.403339499s
1: [369.9s] 11:53:31.897        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 19.656757486s
1: [388.5s] 11:53:50.454        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.557088268s
1: [406.6s] 11:54:08.532        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.07754044s
1: [424.6s] 11:54:26.564        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.031969487s
1: [442.8s] 11:54:44.746        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.181691932s
1: [462.1s] 11:55:04.053        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 19.306398768s
1: [480.0s] 11:55:21.968        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 17.915756378s
1: [498.3s] 11:55:40.252        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.282926433s
1: [516.4s] 11:55:58.366        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.114667786s
1: [534.5s] 11:56:16.414        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.04720991s
1: [552.5s] 11:56:34.452        debug   (time (run (from {:oci-archive (example "oci-archive") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.037956307s
1: [570.7s] 11:56:52.678        debug   (time (run (from {:oci-archive (example "oci") :platform {:os "linux"} :tag "latest"} ($ env) ($ hello)))) => null took 18.225845192s
```