### PR TITLE
use base64-encoded sha256 instead of sha1

### DIFF
--- a/bass.lock
+++ b/bass.lock
@@ -1,6 +1,44 @@
 {
   "memo": {
-    "2d1f994e0a8e466595818ce55744edef890a6d45dfea1d1b22987f85e6fec074:resolve": [
+    "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=:resolve": [
+      {
+        "input": [
+          {
+            "platform": {
+              "os": "linux"
+            },
+            "repository": "nixos/nix",
+            "tag": "latest"
+          }
+        ],
+        "output": {
+          "digest": "sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "nixos/nix",
+          "tag": "latest"
+        }
+      },
+      {
+        "input": [
+          {
+            "platform": {
+              "os": "linux"
+            },
+            "repository": "alpine",
+            "tag": "latest"
+          }
+        ],
+        "output": {
+          "digest": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "alpine",
+          "tag": "latest"
+        }
+      },
       {
         "input": [
           {
@@ -31,7 +69,7 @@
           }
         ],
         "output": {
-          "digest": "sha256:e06c83493ef6d69c95018da90f2887bf337470db074d3c648b8b648d8e3c441e",
+          "digest": "sha256:c7c94588b6445f5254fbc34df941afa10de04706deb330e62831740c9f0f2030",
           "platform": {
             "os": "linux"
           },
@@ -45,59 +83,21 @@
             "platform": {
               "os": "linux"
             },
-            "repository": "alpine",
-            "tag": "latest"
-          }
-        ],
-        "output": {
-          "digest": "sha256:21a3deaa0d32a8057914f36584b5288d2e5ecc984380bc0118285c70fa8c9300",
-          "platform": {
-            "os": "linux"
-          },
-          "repository": "alpine",
-          "tag": "latest"
-        }
-      },
-      {
-        "input": [
-          {
-            "platform": {
-              "os": "linux"
-            },
             "repository": "ubuntu",
             "tag": "latest"
           }
         ],
         "output": {
-          "digest": "sha256:669e010b58baf5beb2836b253c1fd5768333f0d1dbcb834f7c07a4dc93f474be",
+          "digest": "sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9",
           "platform": {
             "os": "linux"
           },
           "repository": "ubuntu",
           "tag": "latest"
         }
-      },
-      {
-        "input": [
-          {
-            "platform": {
-              "os": "linux"
-            },
-            "repository": "nixos/nix",
-            "tag": "latest"
-          }
-        ],
-        "output": {
-          "digest": "sha256:6c7923c366b351002f21671a46e79eafc5d9a9db9da71497b6580e671698d906",
-          "platform": {
-            "os": "linux"
-          },
-          "repository": "nixos/nix",
-          "tag": "latest"
-        }
       }
     ],
-    "97ea7bc7e38a8f9dbbd589a3d00e96c1a9808a27a44524339c93faadbc4a10a3:ls-remote": [
+    "l-p7x-OKj5271Ymj0A6WwamAiiekRSQznJP6rbxKEKM=:ls-remote": [
       {
         "input": [
           "https://github.com/vito/tabs",
@@ -108,12 +108,12 @@
     ]
   },
   "thunks": {
-    "2d1f994e0a8e466595818ce55744edef890a6d45dfea1d1b22987f85e6fec074": {
+    "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=": {
       "cmd": {
         "command": "run"
       }
     },
-    "97ea7bc7e38a8f9dbbd589a3d00e96c1a9808a27a44524339c93faadbc4a10a3": {
+    "l-p7x-OKj5271Ymj0A6WwamAiiekRSQznJP6rbxKEKM=": {
       "cmd": {
         "command": "git"
       },

--- a/demos/bass.lock
+++ b/demos/bass.lock
@@ -1,22 +1,22 @@
 {
   "memo": {
-    "2d1f994e0a8e466595818ce55744edef890a6d45dfea1d1b22987f85e6fec074:resolve": [
+    "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=:resolve": [
       {
         "input": [
           {
             "platform": {
               "os": "linux"
             },
-            "repository": "ubuntu",
+            "repository": "alpine/git",
             "tag": "latest"
           }
         ],
         "output": {
-          "digest": "sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9",
+          "digest": "sha256:d4740deff7f05d2d48771ff66d9d9c26dfb76f0db0aa833b1ea0ee346fa1e48f",
           "platform": {
             "os": "linux"
           },
-          "repository": "ubuntu",
+          "repository": "alpine/git",
           "tag": "latest"
         }
       },
@@ -45,35 +45,16 @@
             "platform": {
               "os": "linux"
             },
-            "repository": "alpine/git",
+            "repository": "ubuntu",
             "tag": "latest"
           }
         ],
         "output": {
-          "digest": "sha256:d4740deff7f05d2d48771ff66d9d9c26dfb76f0db0aa833b1ea0ee346fa1e48f",
+          "digest": "sha256:8ae9bafbb64f63a50caab98fd3a5e37b3eb837a3e0780b78e5218e63193961f9",
           "platform": {
             "os": "linux"
           },
-          "repository": "alpine/git",
-          "tag": "latest"
-        }
-      },
-      {
-        "input": [
-          {
-            "platform": {
-              "os": "linux"
-            },
-            "repository": "golang",
-            "tag": "latest"
-          }
-        ],
-        "output": {
-          "digest": "sha256:ca709802394f4744685c1ecc083965656c3633799a005e90c75c62cafbaf3cee",
-          "platform": {
-            "os": "linux"
-          },
-          "repository": "golang",
+          "repository": "ubuntu",
           "tag": "latest"
         }
       },
@@ -88,30 +69,35 @@
           }
         ],
         "output": {
-          "digest": "sha256:6c7923c366b351002f21671a46e79eafc5d9a9db9da71497b6580e671698d906",
+          "digest": "sha256:fc55b9bf9f61742a3fc262c0dc9ad62ea8ace014bb5bd4b11341da879e7b26ce",
           "platform": {
             "os": "linux"
           },
           "repository": "nixos/nix",
           "tag": "latest"
         }
+      },
+      {
+        "input": [
+          {
+            "platform": {
+              "os": "linux"
+            },
+            "repository": "golang",
+            "tag": "latest"
+          }
+        ],
+        "output": {
+          "digest": "sha256:c7c94588b6445f5254fbc34df941afa10de04706deb330e62831740c9f0f2030",
+          "platform": {
+            "os": "linux"
+          },
+          "repository": "golang",
+          "tag": "latest"
+        }
       }
     ],
-    "97ea7bc7e38a8f9dbbd589a3d00e96c1a9808a27a44524339c93faadbc4a10a3:ls-remote": [
-      {
-        "input": [
-          "https://github.com/vito/bass",
-          "main"
-        ],
-        "output": "1221fb56549f6c484eeef78fa7462a53d749c010"
-      },
-      {
-        "input": [
-          "https://github.com/vito/booklit",
-          "master"
-        ],
-        "output": "02c9a69f76584a1db5eab7b8be379924ae44ddbd"
-      },
+    "l-p7x-OKj5271Ymj0A6WwamAiiekRSQznJP6rbxKEKM=:ls-remote": [
       {
         "input": [
           "https://github.com/vito/tabs",
@@ -121,20 +107,34 @@
       },
       {
         "input": [
+          "https://github.com/vito/bass",
+          "main"
+        ],
+        "output": "4f17f62ff4e7476a2df1f55abfb8a0a54c08e0f8"
+      },
+      {
+        "input": [
           "https://github.com/vito/booklit",
           "HEAD"
+        ],
+        "output": "02c9a69f76584a1db5eab7b8be379924ae44ddbd"
+      },
+      {
+        "input": [
+          "https://github.com/vito/booklit",
+          "master"
         ],
         "output": "02c9a69f76584a1db5eab7b8be379924ae44ddbd"
       }
     ]
   },
   "thunks": {
-    "2d1f994e0a8e466595818ce55744edef890a6d45dfea1d1b22987f85e6fec074": {
+    "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=": {
       "cmd": {
         "command": "run"
       }
     },
-    "97ea7bc7e38a8f9dbbd589a3d00e96c1a9808a27a44524339c93faadbc4a10a3": {
+    "l-p7x-OKj5271Ymj0A6WwamAiiekRSQznJP6rbxKEKM=": {
       "cmd": {
         "command": "git"
       },

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -914,7 +914,7 @@ func (plugin *Plugin) renderThunk(thunk bass.Thunk, pathOptional ...bass.Value) 
 		return nil, err
 	}
 
-	id, err := thunk.SHA1()
+	id, err := thunk.SHA256()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -157,8 +157,8 @@ func (path *FileOrDirPath) FromValue(val Value) error {
 // embedded filesystems, i.e. in Bass's stdlib and test suites.
 //
 // JSON tags are specified just for keeping up appearances - this type needs to
-// be marshalable just to support .SHA1, .SHA256, .Avatar, etc. on a Thunk
-// that embeds it.
+// be marshalable just to support .SHA256, .Name, .Avatar, etc. on a Thunk that
+// embeds it.
 type FSPath struct {
 	ID   string        `json:"fs"`
 	FS   fs.FS         `json:"-"`

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -2,8 +2,8 @@ package bass
 
 import (
 	"context"
-	"crypto/sha1"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -229,7 +229,7 @@ var _ Path = Thunk{}
 // Name returns the unqualified name for the path, i.e. the base name of a
 // file or directory, or the name of a command.
 func (thunk Thunk) Name() string {
-	digest, err := thunk.SHA1()
+	digest, err := thunk.SHA256()
 	if err != nil {
 		// this is awkward, but it's better than panicking
 		return fmt.Sprintf("(error: %s)", err)
@@ -325,16 +325,6 @@ func (thunk *Thunk) Platform() *Platform {
 	return thunk.Image.Platform()
 }
 
-// SHA1 returns a stable SHA1 hash derived from the thunk.
-func (wl Thunk) SHA1() (string, error) {
-	payload, err := json.Marshal(wl)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%x", sha1.Sum(payload)), nil
-}
-
 // SHA256 returns a stable SHA256 hash derived from the thunk.
 func (wl Thunk) SHA256() (string, error) {
 	payload, err := json.Marshal(wl)
@@ -342,7 +332,8 @@ func (wl Thunk) SHA256() (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", sha256.Sum256(payload)), nil
+	sum := sha256.Sum256(payload)
+	return base64.URLEncoding.EncodeToString(sum[:]), nil
 }
 
 // Avatar returns an ASCII art avatar derived from the thunk.

--- a/pkg/bass/thunk_test.go
+++ b/pkg/bass/thunk_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vito/is"
 )
 
-func TestThunkSHA1(t *testing.T) {
+func TestThunkSHA256(t *testing.T) {
 	is := is.New(t)
 
 	// use an object with a ton of keys to test stable order when hashing
@@ -24,10 +24,10 @@ func TestThunkSHA1(t *testing.T) {
 		Env: manyKeys,
 	}
 
-	name, err := thunk.SHA1()
+	name, err := thunk.SHA256()
 	is.NoErr(err)
 
 	// this is a bit silly, but it's deterministic, and we need to make sure it's
 	// always the same value
-	is.Equal(name, "7634e3abd39a1c3bc100beb1f45bf1cdc53dd63b")
+	is.Equal(name, "tHmK3w3nkdCC8OYKYkDUvxY4TaPHWPjvs-uwiyU56eQ=")
 }

--- a/pkg/bass/value_test.go
+++ b/pkg/bass/value_test.go
@@ -469,7 +469,7 @@ func TestString(t *testing.T) {
 					Dir: &bass.DirPath{"dir"},
 				},
 			},
-			"<thunk: (./file) name:d0955ded7ee2f2b91a26798668677f5af4eaf5c1>/./dir/",
+			"<thunk: (./file) name:9G8HrdJgsx_Ok3BiPNxW2FOq--Yd25I0dJq2ECLFDB8=>/./dir/",
 		},
 	} {
 		t.Run(fmt.Sprintf("%T", test.src), func(t *testing.T) {

--- a/pkg/runtimes/bass.go
+++ b/pkg/runtimes/bass.go
@@ -94,7 +94,7 @@ func (runtime *Bass) ExportPath(ctx context.Context, w io.Writer, path bass.Thun
 }
 
 func (runtime *Bass) run(ctx context.Context, thunk bass.Thunk, ext string) (*bass.Scope, []byte, error) {
-	key, err := thunk.SHA1()
+	key, err := thunk.SHA256()
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/runtimes/command.go
+++ b/pkg/runtimes/command.go
@@ -196,7 +196,7 @@ func (cmd *Command) resolveValue(val bass.Value, dest interface{}) error {
 	var artifact bass.ThunkPath
 	if err := val.Decode(&artifact); err == nil {
 		// TODO: it might be worth mounting the entire artifact directory instead
-		name, err := artifact.Thunk.SHA1()
+		name, err := artifact.Thunk.SHA256()
 		if err != nil {
 			return err
 		}

--- a/pkg/runtimes/command_test.go
+++ b/pkg/runtimes/command_test.go
@@ -33,7 +33,7 @@ var wlName string
 
 func init() {
 	var err error
-	wlName, err = wl.SHA1()
+	wlName, err = wl.SHA256()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
previously I used SHA1 for a goofy reason: SHA256 is too long!

the value being hashed here (thunks) doesn't seem prone to collisions, but it's not worth the risk and the alternative is just as easy: just base64-encode sha256 instead.

note that this uses the `URLEncoding` instead of `StdEncoding` to avoid '/' since this ends up in file/directory names.