### PR TITLE
only call (main) for run/read, not (load)

### DIFF
--- a/pkg/runtimes/testdata/bass/inc
+++ b/pkg/runtimes/testdata/bass/inc
@@ -1,3 +1,4 @@
 #!/usr/bin/env bass
 
-(each *stdin* (fn [n] (emit (+ n 1) *stdout*)))
+(defn main []
+  (each *stdin* (fn [n] (emit (+ n 1) *stdout*))))

--- a/pkg/runtimes/testdata/bass/numbers.bass
+++ b/pkg/runtimes/testdata/bass/numbers.bass
@@ -1,2 +1,5 @@
 (defn inc [n]
   (+ n 1))
+
+(defn main []
+  (error "this should not be called"))


### PR DESCRIPTION
allows libraries to contain a simple test/demo `(main)`