### PR TITLE
support remounting thunk output dir

### DIFF
--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -158,6 +158,14 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 			File:   "oci-archive-image.bass",
 			Result: bass.String("Hello, Bass!\n"),
 		},
+		{
+			File: "remount-workdir.bass",
+			Result: bass.NewList(
+				bass.NewList(bass.String("bar")),
+				bass.NewList(bass.String("baz")),
+				bass.NewList(bass.String("foo")),
+			),
+		},
 	} {
 		test := test
 		t.Run(filepath.Base(test.File), func(t *testing.T) {

--- a/pkg/runtimes/testdata/remount-workdir.bass
+++ b/pkg/runtimes/testdata/remount-workdir.bass
@@ -1,0 +1,17 @@
+(def initial
+  (-> ($ touch ./foo)
+      (with-image (linux/alpine))
+      (subpath ./)))
+
+(def remount
+  (-> ($ touch ./bar)
+      (with-image (linux/alpine))
+      (with-mount initial ./)))
+
+(def from-remount
+  (from remount
+    ($ touch ./baz)))
+
+(let [files (read (from from-remount ($ ls)) :unix-table)]
+  ; alphabetically sorted, so bar baz foo
+  [(next files) (next files) (next files)])


### PR DESCRIPTION
this allows for a common practice: mounting in a source repository, running a local-dir-modifying command (`make`, `git commit`), and passing the modified directory on to subsequent thunks (`tar -czf`, `git push`, etc).