### PR TITLE
set file mtimes in thunk outputs to 1985-10-26T08:15:00Z

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -100,7 +100,6 @@ require (
 	golang.org/x/crypto v0.0.0-20211202192323-5770296d904e // indirect
 	golang.org/x/mod v0.4.2 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
-	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	golang.org/x/tools v0.1.5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/mattn/go-unicodeclass v0.0.1
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.10.0-rc1.0.20220219004526-a1cfefeaeb66
+	github.com/moby/sys/mountinfo v0.5.0
 	github.com/morikuni/aec v1.0.0
 	github.com/neovim/go-client v1.2.2-0.20220118223211-7c85d516f28c
 	github.com/opencontainers/go-digest v1.0.0
@@ -35,6 +36,7 @@ require (
 	github.com/vito/vt100 v0.0.0-20211217051322-45a31b434dad
 	go.uber.org/zap v1.19.1
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9
 	golang.org/x/term v0.0.0-20210615171337-6886f2dfbf5b
 )
 

--- a/nix/images.bass
+++ b/nix/images.bass
@@ -1,6 +1,3 @@
-(def *root*
-  (next *stdin*))
-
 ; image used for bootstrapping git so other libs can be fetched
 (def git-bootstrap
   (linux/alpine/git))
@@ -14,25 +11,25 @@
   (use (.git git-bootstrap)
        (git:github/vito/tabs/ref/main/nix))
 
-  (def deps-archive
+  (defn deps-archive [src]
     (nix:build-flake
       (-> ($ nix build ".#depsArchive")
-          (with-mount *dir* ./nix/)
-          (with-mount *root*/flake.nix ./flake.nix)
-          (with-mount *root*/flake.lock ./flake.lock)
-          (with-mount *root*/default.nix ./default.nix))
+          (with-mount src/nix/ ./nix/)
+          (with-mount src/flake.nix ./flake.nix)
+          (with-mount src/flake.lock ./flake.lock)
+          (with-mount src/default.nix ./default.nix))
       ./image.tar))
 
   ; monolithic image containing dependencies for building and testing
-  (def deps
-    {:oci-archive deps-archive
+  (defn deps [src]
+    {:oci-archive (deps-archive src)
      :platform {:os "linux"}
      :tag "latest"}))
 
 ; deps with Go dependencies pre-fetched
-(defn go-deps [go.mod go.sum]
-  (from deps
-    ($ cp $go.mod $go.sum ./)
+(defn go-deps [src]
+  (from (deps src)
+    ($ cp src/go.mod src/go.sum ./)
     ($ go mod download)))
 
 ; image used for performing nix checks

--- a/nix/vendorSha256.txt
+++ b/nix/vendorSha256.txt
@@ -1,1 +1,1 @@
-sha256-uG9u7VTiGHhrlxA6gThzA15kOGz13LjkMgG2rqdLiuI=
+sha256-gDsTetCcr4Og1s/fKwB2PL4hB6P4Kn3cwYrvI8eXgS0=

--- a/pkg/runtimes/shim/main.go
+++ b/pkg/runtimes/shim/main.go
@@ -38,7 +38,7 @@ func init() {
 
 func main() {
 	if len(os.Args) == 1 {
-		fmt.Fprintf(os.Stderr, "usage: %s <unpack|get-config|run>", os.Args[0])
+		fmt.Fprintf(os.Stderr, "usage: %s <unpack|get-config|run>\n", os.Args[0])
 		os.Exit(1)
 	}
 
@@ -52,7 +52,7 @@ func main() {
 		os.Exit(run(os.Args[1:]))
 		return
 	default:
-		fmt.Fprintln(os.Stderr, "exe must be named unpack, get-config, or run")
+		fmt.Fprintf(os.Stderr, "usage: %s <unpack|get-config|run>\n", os.Args[0])
 		os.Exit(1)
 		return
 	}

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -166,6 +166,13 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 				bass.NewList(bass.String("foo")),
 			),
 		},
+		{
+			File: "timestamps.bass",
+			Result: bass.NewList(
+				bass.NewList(bass.String("499162500"), bass.String("499162500")),
+				bass.NewList(bass.String("499162500"), bass.String("499162500")),
+			),
+		},
 	} {
 		test := test
 		t.Run(filepath.Base(test.File), func(t *testing.T) {

--- a/pkg/runtimes/testdata/timestamps.bass
+++ b/pkg/runtimes/testdata/timestamps.bass
@@ -1,0 +1,14 @@
+(def touch
+  (from (linux/alpine)
+    ($ touch ./foo)
+    ($ mkdir -p ./some/deep/dir/)
+    ($ touch ./some/deep/dir/path)))
+
+(defn times [file]
+  (-> ($ stat -c "%X %Y" $file)
+      (with-image (linux/alpine))
+      (read :unix-table)
+      next))
+
+[(times touch/foo)
+ (times touch/some/deep/dir/path)]

--- a/project.bass
+++ b/project.bass
@@ -1,6 +1,6 @@
 ; load dependencies
 (use (.strings)
-     (*dir*/nix/images *dir*)
+     (*dir*/nix/images)
      (.git images:git-bootstrap))
 
 ; root of the git repository
@@ -27,32 +27,32 @@
   (defn build [src version os arch]
     (let [staged (from (make src version os arch)
                    ($ make "DESTDIR=./out/" install))]
-      (archive staged/out/ os arch)))
+      (archive src staged/out/ os arch)))
 
   ; returns a thunk with the make targets built into the output directory, as
   ; an overlay of src
   (defn make [src version os arch]
     (-> ($ make -j (str "GOOS=" os) (str "GOARCH=" arch))
         (with-mount src ./)
-        (with-image (images:go-deps src/go.mod src/go.sum))))
+        (with-image (images:go-deps src))))
 
   ; creates an archive appropriate for the given platform
-  (defn archive [out os arch]
+  (defn archive [src out os arch]
     (let [prefix (str "bass." os "-" arch)
           tgz-path (string->fs-path (str prefix ".tgz"))
           zip-path (string->fs-path (str prefix ".zip"))]
       (if (= os "windows")
-        (zip zip-path out ./bass)
-        (tar-czf tgz-path out ./bass))))
+        (zip src zip-path out ./bass)
+        (tar-czf src tgz-path out ./bass))))
 
-  (defn tar-czf [tarname dir & files]
+  (defn tar-czf [src tarname dir & files]
     (-> ($ tar -C $dir -czf $tarname & $files)
-        (with-image images:deps)
+        (with-image (images:deps src))
         (subpath tarname)))
 
-  (defn zip [zipname dir & files]
+  (defn zip [src zipname dir & files]
     (-> ($ zip (../ zipname) & $files)
-        (with-image images:deps)
+        (with-image (images:deps src))
         (with-dir dir)
         (subpath zipname)))
 

--- a/project.bass
+++ b/project.bass
@@ -32,10 +32,7 @@
   ; returns a thunk with the make targets built into the output directory, as
   ; an overlay of src
   (defn make [src version os arch]
-    (-> ($ make -j
-           (str "VERSION=" version)
-           (str "GOOS=" os)
-           (str "GOARCH=" arch))
+    (-> ($ make -j (str "GOOS=" os) (str "GOARCH=" arch))
         (with-mount src ./)
         (with-image (images:go-deps src/go.mod src/go.sum))))
 


### PR DESCRIPTION
File `mtime`s are kryptonite for reproducible builds. This change extends the shim to set the `atime`/`mtime` for each file in the thunk's output mount to the following time:

> October 26, 1985 at 1:15 AM PST

or as a Unix timestamp, `499162500`.

As a result, Bass's self-build is now reproducible!

    $ ./ci/build https://github.com/vito/bass/commit/1ff7a699621d9bdad718ee096984ed2c952bdaa4 linux amd64 | bass -e | sha256sum
    ad87286daf4c614f1948a837f88b5cd1674a7a71d7851beecc1c75c130fc1064
    $ bass --prune
    $ ./ci/build https://github.com/vito/bass/commit/1ff7a699621d9bdad718ee096984ed2c952bdaa4 linux amd64 | bass -e | sha256sum
    ad87286daf4c614f1948a837f88b5cd1674a7a71d7851beecc1c75c130fc1064

This arbitrary timestamp is the same one used by npm[^1]. Notably it isn't the Unix epoch since some tools (i.e. zip) don't behave well with that.

[^1]:  https://github.com/npm/cli/commit/58d2aa58d5f9c4db49f57a5f33952b3106778669