### PR TITLE
bring back make VERSION= after all

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DESTDIR ?= $(shell go env GOPATH)/bin
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
+VERSION ?= dev
 
 arches=amd64 arm arm64
 shims=$(foreach arch,$(arches),pkg/runtimes/bin/exe.$(arch))
@@ -13,7 +14,7 @@ pkg/runtimes/bin/exe.%: pkg/runtimes/shim/main.go
 
 cmd/bass/bass: $(shims)
 	upx $(shims) || true # swallow AlreadyPackedException :/
-	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -trimpath -o ./cmd/bass/bass ./cmd/bass
+	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -trimpath -ldflags "-X main.version=$(VERSION)" -o ./cmd/bass/bass ./cmd/bass
 
 nix/vendorSha256.txt: go.mod go.sum
 	./hack/get-nix-vendorsha > $@

--- a/ci/shipit
+++ b/ci/shipit
@@ -90,8 +90,8 @@
 ;
 ; Needs the tag to checkout, build, and publish along with a title for the
 ; release.
-(defn main [tag title]
-  (let [src (project:checkout tag)
+(defn main [sha tag title]
+  (let [src (project:checkout sha)
         notes (project:release-notes src tag)
         assets (build-assets src tag)
         release-url (create-release sha title tag notes assets)]

--- a/cmd/bass/main.go
+++ b/cmd/bass/main.go
@@ -82,7 +82,7 @@ var DefaultConfig = bass.Config{
 
 func root(ctx context.Context, argv []string) error {
 	if showVersion {
-		version(ctx)
+		printVersion(ctx)
 		return nil
 	}
 

--- a/cmd/bass/version.go
+++ b/cmd/bass/version.go
@@ -7,7 +7,10 @@ import (
 	"runtime/debug"
 )
 
-func version(ctx context.Context) {
+// overridden by ldflags
+var version string = "dev"
+
+func printVersion(ctx context.Context) {
 	info, ok := debug.ReadBuildInfo()
 	if !ok {
 		fmt.Fprintln(os.Stderr, "impossible: build info unavailable")
@@ -33,7 +36,7 @@ func version(ctx context.Context) {
 		rev += "*"
 	}
 
-	fmt.Printf("bass\t%s\n", info.Main.Version)
+	fmt.Printf("bass\t%s\n", version)
 
 	if rev != "" {
 		fmt.Printf("commit\t%s\n", rev)

--- a/project.bass
+++ b/project.bass
@@ -32,7 +32,10 @@
   ; returns a thunk with the make targets built into the output directory, as
   ; an overlay of src
   (defn make [src version os arch]
-    (-> ($ make -j (str "GOOS=" os) (str "GOARCH=" arch))
+    (-> ($ make -j
+           (str "VERSION=" version)
+           (str "GOOS=" os)
+           (str "GOARCH=" arch))
         (with-mount src ./)
         (with-image (images:go-deps src))))
 


### PR DESCRIPTION
buildinfo.Main.Version is always (devel)