### PR TITLE
fix inconsistent hashing of thunks with HTML chars

### DIFF
--- a/pkg/bass/log.go
+++ b/pkg/bass/log.go
@@ -1,7 +1,6 @@
 package bass
 
 import (
-	"encoding/json"
 	"fmt"
 	"io"
 	"time"
@@ -30,7 +29,7 @@ func Logger() *zap.Logger {
 }
 
 func Dump(dst io.Writer, val interface{}) {
-	enc := json.NewEncoder(dst)
+	enc := NewEncoder(dst)
 	enc.SetIndent("", "  ")
 	err := enc.Encode(val)
 	if err != nil {

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -309,7 +309,7 @@ func (combiner Thunk) Call(ctx context.Context, val Value, scope *Scope, cont Co
 
 func (thunk *Thunk) UnmarshalJSON(b []byte) error {
 	var obj *Scope
-	err := json.Unmarshal(b, &obj)
+	err := UnmarshalJSON(b, &obj)
 	if err != nil {
 		return err
 	}
@@ -327,7 +327,7 @@ func (thunk *Thunk) Platform() *Platform {
 
 // SHA256 returns a stable SHA256 hash derived from the thunk.
 func (wl Thunk) SHA256() (string, error) {
-	payload, err := json.Marshal(wl)
+	payload, err := MarshalJSON(wl)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/bass/thunk_test.go
+++ b/pkg/bass/thunk_test.go
@@ -22,12 +22,16 @@ func TestThunkSHA256(t *testing.T) {
 			File: &bass.FilePath{"run"},
 		},
 		Env: manyKeys,
+		Args: []bass.Value{
+			// ensure HTML characters are not escaped
+			bass.String("foo >> bar"),
+		},
 	}
 
-	name, err := thunk.SHA256()
+	sha2, err := thunk.SHA256()
 	is.NoErr(err)
 
 	// this is a bit silly, but it's deterministic, and we need to make sure it's
 	// always the same value
-	is.Equal(name, "tHmK3w3nkdCC8OYKYkDUvxY4TaPHWPjvs-uwiyU56eQ=")
+	is.Equal(sha2, "Cr6qKfJTmQF_OMFyTEHyfpQ6_1Zwm3XL0ONT6P4QzuU=")
 }


### PR DESCRIPTION
Previously, if you built a thunk path, ran it, and then emitted it to `*stdout*` to `bass --export`, if the thunk contained `<>` anywhere within it the `bass --export` would end up re-running the thunk with a different hash.

This was happening because `Thunk.SHA256` used regular old `encoding/json` instead of `bass.MarshalJSON` which is what emitting to `*stdout*` does. `bass.MarshalJSON` does `SetEscapeHTML(false)` since we don't really need HTML escaping, which is the default for `json.Marshal`.

Now the encoding is consistent between the two so the hashes align properly.

Applied the same fix for `(dump)` too.