### PR TITLE
make shims separately for better caching

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,6 @@ pkg/runtimes/bin/exe.%: pkg/runtimes/shim/main.go
 	env GOOS=linux GOARCH=$* CGO_ENABLED=0 go build -ldflags "-s -w" -o $@ ./pkg/runtimes/shim
 
 cmd/bass/bass: $(shims)
-	upx $(shims) || true # swallow AlreadyPackedException :/
 	env GOOS=$(GOOS) GOARCH=$(GOARCH) CGO_ENABLED=0 go build -trimpath -ldflags "-X main.version=$(VERSION)" -o ./cmd/bass/bass ./cmd/bass
 
 nix/vendorSha256.txt: go.mod go.sum
@@ -21,6 +20,7 @@ nix/vendorSha256.txt: go.mod go.sum
 
 .PHONY: shims
 shims: $(shims)
+	upx $(shims) || true # swallow AlreadyPackedException :/
 
 .PHONY: install
 install: cmd/bass/bass

--- a/ci/shipit
+++ b/ci/shipit
@@ -31,8 +31,8 @@
 ;
 ; Makes sure to to mount each file in to the working directory so that the
 ; output can be passed to sha256sum --check --ignore-missing.
-(defn sha256sums [files]
-  (-> (from project:images:deps
+(defn sha256sums [src files]
+  (-> (from (project:images:deps src)
         (foldl
           (fn [t f] (with-mount t f (path-base f)))
           (with-args (.sha256sum) (map path-base files))
@@ -46,7 +46,7 @@
         archives (vals bins)
         repros (reduce-kv (fn [acc k v] (cons (archive-repro k v) acc)) [] bins)
         files (append archives repros)
-        sums (mkfile ./sha256sums.txt (sha256sums files))]
+        sums (mkfile ./sha256sums.txt (sha256sums src files))]
     (conj files sums)))
 
 ; returns true if the tag looks like a prerelease version
@@ -64,15 +64,15 @@
 ; body which makes it look pretty hideous on the desktop.
 ;
 ; Returns a memory-backed file, so this can be shimmed in-place.
-(defn undo-wordwrap [file]
+(defn undo-wordwrap [src file]
   (mkfile ./wide.txt
     (-> ($ fmt -w999 $file)
-        (with-image project:images:deps)
+        (with-image (project:images:deps src))
         (read :raw)
         next)))
 
 ; creates a release with the given assets
-(defn create-release [sha title tag notes assets]
+(defn create-release [src sha title tag notes assets]
   (let [release (project:auth-release (mask *env*:GITHUB_TOKEN :github-token))]
     (logf "running smoke tests")
     (project:smoke-test assets/bass.linux-amd64.tgz)
@@ -82,7 +82,7 @@
       tag sha assets
       {:title title
        :generate-notes true
-       :notes-file (undo-wordwrap notes)
+       :notes-file (undo-wordwrap src notes)
        :prerelease (prerelease? tag)
        :discussion-category (if pre? "" "General")})))
 
@@ -94,5 +94,5 @@
   (let [src (project:checkout sha)
         notes (project:release-notes src tag)
         assets (build-assets src tag)
-        release-url (create-release sha title tag notes assets)]
+        release-url (create-release src sha title tag notes assets)]
     (logf "release published to %s" release-url)))

--- a/project.bass
+++ b/project.bass
@@ -25,17 +25,19 @@
 (provide [build smoke-test tests docs]
   ; compiles a bass binary for the given platform and puts it in an archive
   (defn build [src version os arch]
-    (let [staged (from (make src version os arch)
-                   ($ make "DESTDIR=./out/" install))]
+    (let [staged (from (make-shims src)
+                   ($ make
+                      (str "VERSION=" version)
+                      (str "GOOS=" os)
+                      (str "GOARCH=" arch)
+                      "DESTDIR=./out/"
+                      install))]
       (archive src staged/out/ os arch)))
 
   ; returns a thunk with the make targets built into the output directory, as
   ; an overlay of src
-  (defn make [src version os arch]
-    (-> ($ make -j
-           (str "VERSION=" version)
-           (str "GOOS=" os)
-           (str "GOARCH=" arch))
+  (defn make-shims [src]
+    (-> ($ make -j shims)
         (with-mount src ./)
         (with-image (images:go-deps src))))
 
@@ -82,7 +84,7 @@
   (defn with-deps [src test-thunk]
     (-> test-thunk
         (wrap-cmd ./hack/with-deps) ; TODO: maybe swap the order here
-        (with-image (make src "dev" "linux" "amd64"))
+        (with-image (make-shims src))
         ; runtime tests currently need elevated privileges
         insecure!))
 


### PR DESCRIPTION
move upx into phony shims target, now a prerequisite of cmd/bass/bass,
so that we do the actual upx compression once, at shim building time,
rather than in parallel for each bass CLI platform build.

cmd/bass/bass is already somewhat phony since it doesn't point to go
sources; this makes it actually phony which is honestly better off
anyway

also fixup shipit image deps usage along the way