### PR TITLE
fix missing fmt command

### DIFF
--- a/nix/deps.nix
+++ b/nix/deps.nix
@@ -22,6 +22,8 @@ pkgs.dockerTools.streamLayeredImage {
     gzip
     gnutar
     zip
+    # provides fmt, for un-wordwrapping release notes
+    coreutils
     # git plumbing
     git
     # compressing shim binaries
@@ -30,8 +32,6 @@ pkgs.dockerTools.streamLayeredImage {
     gnumake
     # bare necessitites (cp, find, which, etc)
     busybox
-    # un-wordwrapping release notes
-    fmt
   ];
   config = {
     Env = [


### PR DESCRIPTION
* fix wrong package (doy)

kind of annoying that I have to keep pushing to test this, since building now depends on the checked out repo, but that's kind of necessary since host paths aren't reproducible.

i could maybe write some tests for this that run against local host paths though.