### PR TITLE
shipit: publish windows binary, fix zipping

### DIFF
--- a/ci/shipit
+++ b/ci/shipit
@@ -10,7 +10,8 @@
 (def supported-os-arches
   [["linux" "amd64"]
    ["darwin" "amd64"]
-   ["darwin" "arm64"]])
+   ["darwin" "arm64"]
+   ["windows" "amd64"]])
 
 ; returns the bass binary archives for each supported os + arch
 (defn all-bins [src tag]
@@ -74,14 +75,15 @@
 
 ; creates a release with the given assets
 (defn create-release [src sha title tag notes assets]
-  (let [release (project:auth-release (mask *env*:GITHUB_TOKEN :github-token))]
+  (let [release (project:auth-release (mask *env*:GITHUB_TOKEN :github-token))
+        pre? (prerelease? tag)]
     (logf "shipping bass @ %s with tag %s" sha)
     (release:create!
       tag sha assets
       {:title title
        :generate-notes true
        :notes-file (undo-wordwrap src notes)
-       :prerelease (prerelease? tag)
+       :prerelease pre?
        :discussion-category (if pre? "" "General")})))
 
 ; builds and publishes a GitHub release

--- a/project.bass
+++ b/project.bass
@@ -30,9 +30,9 @@
                       (str "VERSION=" version)
                       (str "GOOS=" os)
                       (str "GOARCH=" arch)
-                      "DESTDIR=./out/"
+                      "DESTDIR=./"
                       install))]
-      (archive src staged/out/ os arch)))
+      (archive src staged/./ os arch)))
 
   ; returns a thunk with the make targets built into the output directory, as
   ; an overlay of src


### PR DESCRIPTION
hmmm, zip didn't work because `dir` is actually `<thunk-path>/out/` which meant it needed to pass `../../` which felt gross. tried mounting it to ./ instead but that also didn't work.

changed the `make install` to just create it in `./` instead of `./out/` to work around this awkwardness.

also: fix pre? binding