### PR TITLE
:oci-archive -> :file

### DIFF
--- a/demos/nix.bass
+++ b/demos/nix.bass
@@ -6,8 +6,8 @@
     ./image.tar))
 
 (run
-  (from {:platform {:os "linux"}
-         :oci-archive example
+  (from {:file example
+         :platform {:os "linux"}
          :tag "latest"}
     ($ env)
     ($ hello)))

--- a/nix/images.bass
+++ b/nix/images.bass
@@ -22,7 +22,7 @@
 
   ; monolithic image containing dependencies for building and testing
   (defn deps [src]
-    {:oci-archive (deps-archive src)
+    {:file (deps-archive src)
      :platform {:os "linux"}
      :tag "latest"}))
 

--- a/pkg/bass/thunk_types.go
+++ b/pkg/bass/thunk_types.go
@@ -21,7 +21,7 @@ type ThunkImageRef struct {
 	Repository string `json:"repository,omitempty"`
 
 	// An OCI image archive tarball to load.
-	OCIArchive *ThunkPath `json:"oci_archive,omitempty"`
+	File *ThunkPath `json:"file,omitempty"`
 
 	// The tag to use, either from the repository or in a multi-tag OCI archive.
 	Tag string `json:"tag,omitempty"`

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -516,8 +516,8 @@ func (b *builder) imageRef(ctx context.Context, image *bass.ThunkImage) (llb.Sta
 	}
 
 	if image.Ref != nil {
-		if image.Ref.OCIArchive != nil {
-			return b.unpackImageArchive(ctx, *image.Ref.OCIArchive, image.Ref.Tag)
+		if image.Ref.File != nil {
+			return b.unpackImageArchive(ctx, *image.Ref.File, image.Ref.Tag)
 		}
 
 		ref, err := image.Ref.Ref()

--- a/pkg/runtimes/testdata/oci-archive-image.bass
+++ b/pkg/runtimes/testdata/oci-archive-image.bass
@@ -5,8 +5,8 @@
       ($ cp ./result ./image.tar))
     ./image.tar))
 
-(-> (from {:platform {:os "linux"}
-           :oci-archive hello
+(-> (from {:file hello
+           :platform {:os "linux"}
            :tag "latest"}
       ($ bash -c "hello --greeting=\"$GREETING\""))
     (read :raw)


### PR DESCRIPTION
`oci-archive` felt oddly specific; images are always OCI, and are either a repository or a file path.

I don't think we want to get into formats until we really have to for the sake of simplicity, and at that point we might want to change references, too.