### PR TITLE
binding a :keyword is const compare with Symbol instead

### DIFF
--- a/pkg/bass/binding_test.go
+++ b/pkg/bass/binding_test.go
@@ -241,18 +241,27 @@ func TestBinding(t *testing.T) {
 			},
 		},
 		{
-			Name:     "keyword match",
+			Name:     "keyword match symbol",
 			Params:   bass.Keyword("hello"),
-			Value:    bass.Keyword("hello"),
+			Value:    bass.Symbol("hello"),
 			Bindings: bass.Bindings{},
 		},
 		{
-			Name:   "keyword mismatch",
+			Name:   "keyword mismatch symbol",
 			Params: bass.Keyword("hello"),
-			Value:  bass.Keyword("goodbye"),
+			Value:  bass.Symbol("goodbye"),
 			Err: bass.BindMismatchError{
-				Need: bass.Keyword("hello"),
-				Have: bass.Keyword("goodbye"),
+				Need: bass.Symbol("hello"),
+				Have: bass.Symbol("goodbye"),
+			},
+		},
+		{
+			Name:   "keyword mismatch keyword",
+			Params: bass.Keyword("hello"),
+			Value:  bass.Keyword("hello"),
+			Err: bass.BindMismatchError{
+				Need: bass.Symbol("hello"),
+				Have: bass.Keyword("hello"),
 			},
 		},
 	} {

--- a/pkg/bass/keyword.go
+++ b/pkg/bass/keyword.go
@@ -49,7 +49,7 @@ func (value Keyword) Eval(_ context.Context, _ *Scope, cont Cont) ReadyCont {
 var _ Bindable = Keyword("")
 
 func (binding Keyword) Bind(_ context.Context, _ *Scope, cont Cont, val Value, _ ...Annotated) ReadyCont {
-	return cont.Call(binding, BindConst(binding, val))
+	return cont.Call(binding, BindConst(binding.Symbol(), val))
 }
 
 func (Keyword) EachBinding(func(Symbol, Range) error) error {


### PR DESCRIPTION
this is how I expected it to work in std/git.bass; seems more intuitive, as otherwise there's no good way to switch on a symbol:

```clojure
(case (next foo :none)
  :none (error "no foo provided")
  val val)
```