### PR TITLE
cons forms satisfy `pair?`

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -879,12 +879,22 @@ var primPreds = []primPred{
 
 	{"pair?", func(val Value) bool {
 		var x Pair
-		return val.Decode(&x) == nil
+		if val.Decode(&x) == nil {
+			return true
+		}
+
+		var c Cons
+		if val.Decode(&c) == nil {
+			return true
+		}
+
+		return false
 	}, []string{
 		`returns true if the value is a pair`,
 		`=> (pair? [])`,
 		`=> (pair? [1])`,
 		`=> (pair? [1 & 2])`,
+		`=> (pair? (quote [1 & 2]))`,
 	}},
 
 	{"applicative?", IsApplicative, []string{

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -295,6 +295,7 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 			Name: "pair?",
 			Trues: []bass.Value{
 				pair,
+				cons,
 			},
 			Falses: []bass.Value{
 				bass.Empty{},
@@ -302,7 +303,6 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 				bass.Null{},
 				scope,
 				bind,
-				cons,
 			},
 		},
 		{


### PR DESCRIPTION
previously, neither `pair?` nor `list?` would return true for this form:

```clojure
[a & b]
```

so this changes `pair?` to also return true for `Cons` values (square brackets).

admittedly, the naming with list/cons/pair is awfully inconsistent between Go and Bass right now.

in Bass, a `list?` value must be a linked list - a `List` whose second value is another List. both Cons and Pair can satisfy this.

in Go, `List` is the interface implemented by `Cons` and `Pair`, but it doesn't ensure that the second value is a list, so it's not always a `list?`.

in Bass, a `pair?` value used to be ONLY the `Pair` type. now it will be `true` of `Cons` as well.

here's the old truth table:

```
         []  ()  [1 2] (1 2) [1 & 2] (1 & 2)
list?    1   1     1     1      0       0
pair?    0   0     0     1      0       1
empty?   1   1     0     0      0       0
```

here's the new truth table:

```
         []  ()  [1 2] (1 2) [1 & 2] (1 & 2)
list?    1   1     1     1      0       0
pair?    0   0     1     1      1       1
empty?   1   1     0     0      0       0
```

there is no `cons?` - just as there is no `keyword?`, but there is `symbol?`. there may be a good reason to add both in the future, but I'm waiting for it to arrive.

an alternative approach here might be to have `Cons` support decoding into `Pair`, but that may be the path to darkness. `Value.Decode` explicitly calls out that it shouldn't be used for converting between `Value` types, though I don't remember if that's coming from a footgun or if it's speculative.