### PR TITLE
add (curryfn), use it for defining path roots

### DIFF
--- a/demos/curry.bass
+++ b/demos/curry.bass
@@ -1,0 +1,12 @@
+(use (.git (linux/alpine/git)))
+
+; git paths are implemented with curryfn
+(log git:github/vito/booklit/ref/master/)
+
+(def plus-3
+  (curryfn [a b c & ds]
+    (+ a b c & ds)))
+
+(log plus-3)
+(log (((plus-3 1) 2) 3))
+(log (((plus-3 1) 2) 3 4 5 6))

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -1350,6 +1350,26 @@ func TestGroundStdlib(t *testing.T) {
 			Bindings: bass.Bindings{},
 		},
 		{
+			Name:   "curryfn",
+			Bass:   "((((curryfn [x y z & more] (* x y z & more)) 2) 3) 4 5 6)",
+			Result: bass.Int(720),
+		},
+		{
+			Name:   "curryfn variadic (for some reason)",
+			Bass:   "((curryfn more (* & more)) 2 3 4 5 6)",
+			Result: bass.Int(720),
+		},
+		{
+			Name:   "curryfn single (for some reason)",
+			Bass:   "((curryfn [a] a) 42)",
+			Result: bass.Int(42),
+		},
+		{
+			Name:   "curryfn empty (for some reason)",
+			Bass:   "((curryfn [] 42))",
+			Result: bass.Int(42),
+		},
+		{
 			Name:   "defn",
 			Bass:   "(defn foo [x] (def local (* x 2)) [local (* local 2)])",
 			Result: bass.Symbol("foo"),

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -1974,11 +1974,11 @@ func TestGroundCase(t *testing.T) {
 		{
 			Name:     "case matching none",
 			Bass:     "(case 3 1 :one 2 :two)",
-			ErrEqual: fmt.Errorf("no matching case branch: 3"),
+			ErrEqual: fmt.Errorf("no matching case branch for 3"),
 		},
 		{
 			Name:   "case binding",
-			Bass:   `(def a 1)[a (case 2 a a) a]`,
+			Bass:   `(def a 1) [a (case 2 a a) a]`,
 			Result: bass.NewList(bass.Int(1), bass.Int(2), bass.Int(1)),
 		},
 		{

--- a/pkg/lsp/analyzer.go
+++ b/pkg/lsp/analyzer.go
@@ -29,9 +29,9 @@ type LexicalBinding struct {
 }
 
 func (analyzer *LexicalAnalyzer) Analyze(ctx context.Context, form bass.Annotate) {
-	var alreadyAnalyzed bass.Annotated
+	var alreadyAnalyzed bass.Annotate
 	if form.Value.Decode(&alreadyAnalyzed) == nil {
-		// prevent double-analyzing commented forms
+		// skip analyzing the outer annotations (range/comments/etc)
 		return
 	}
 

--- a/std/git.bass
+++ b/std/git.bass
@@ -12,10 +12,12 @@
   ;
   ; => (git:ls-remote "https://github.com/vito/bass" "main")
   (defn ls-remote [repo ref]
-    (let [ls (from *git-image*
-               (-> ($ git ls-remote $repo $ref)
-                   (with-label :at (now 0))))]
-      (first (next (read ls :unix-table)))))
+    (-> ($ git ls-remote $repo $ref)
+        (with-image *git-image*)
+        (with-label :at (now 0))
+        (read :unix-table)
+        next
+        first))
 
   ; returns the repo checked out to the given ref
   ;
@@ -31,8 +33,7 @@
   (defn checkout [repo ref]
     (subpath
       (from *git-image*
-        (-> ($ git clone $repo ./)
-            (with-label :for ref))
+        (-> ($ git clone $repo ./) (with-label :for ref))
         ($ git checkout $ref)
         ($ git submodule update --init --recursive))
       ./))
@@ -40,7 +41,7 @@
   (defn memo-ls-remote [memos]
     (memo memos (.git *git-image*) :ls-remote))
 
-  (defn seg [path-or-str]
+  (defn arg [path-or-str]
     (if (string? path-or-str)
       path-or-str
       (path-name path-or-str)))
@@ -51,18 +52,14 @@
   ; somehow make it a non-issue.)
   ;
   ; => (use (.git (linux/alpine/git)))
-  (defn path [memos url]
-    (fn [user]
-      (fn [repo]
-        (let [uri (str url "/" (seg user) "/" (seg repo))]
-          (fn [route]
-            (case route
-              ./sha/
-              (fn [sha] (checkout uri (seg sha)))
-
-              ./ref/
-              (fn [ref]
-                (checkout uri ((memo-ls-remote memos) uri (seg ref)))))))))))
+  (defn path [memos root]
+    (curryfn [user repo route val]
+      (let [uri (str root "/" (arg user) "/" (arg repo))
+            ref (arg val)
+            sha (case route
+                  ./sha/ ref
+                  ./ref/ ((memo-ls-remote memos) uri ref))]
+        (checkout uri sha)))))
 
 ; a path root for repos hosted at github.com
 ;

--- a/std/root.bass
+++ b/std/root.bass
@@ -349,7 +349,7 @@
 (provide (case)
   (defn case-branches [scope val branches]
     (if (empty? branches)
-      (errorf "no matching case branch: %s" val)
+      (errorf "no matching case branch for %s" val)
       (let [[pattern expr & rest] branches
             child (make-scope scope)]
         (if (bind child pattern val)

--- a/std/root.bass
+++ b/std/root.bass
@@ -414,3 +414,17 @@
     (or (recall-memo memos thunk binding args)
         (store-memo memos thunk binding args
                     (apply (binding (load thunk)) args)))))
+
+(provide [curryfn]
+  (defn curry [formals body]
+    (case formals
+      [a]      [fn [a] & body]
+      [a & as] (if (pair? as)
+                 [fn [a] (curry as body)]
+                 [fn [a & as] & body])
+      variadic [fn variadic & body]))
+
+  ; returns a fn which accepts args one value at a time
+  ^:indent
+  (defop curryfn [args & body] scope
+    (eval (curry args body) scope)))


### PR DESCRIPTION
`(curryfn [a b c] (+ a b c)` is:

```clojure
(fn [a] (fn [b] (fn [c] (+ a b c)))
```

handy for defining path roots (like `git:github`), since paths are actually chained single-arg function calls

*plus a few odd cleanups I can't be bothered to split into a separate branch*