### PR TITLE
nicer error formatting, detailed thunk errors

### DIFF
--- a/.bassignore
+++ b/.bassignore
@@ -1,1 +1,3 @@
 Session.vim
+go.work
+go.work.sum

--- a/demos/multi-fail.bass
+++ b/demos/multi-fail.bass
@@ -1,0 +1,14 @@
+(defn ese [msg seconds exit-code]
+  (subpath
+    (from (linux/alpine)
+      (with-label ($ sleep (str seconds)) :at (now 0))
+      ($ sh -c (str "echo $0; exit " exit-code) $msg))
+    ./))
+
+(defn ls paths
+  (run (from (linux/alpine)
+         ($ ls & $paths))))
+
+(defn main []
+  (ls (ese "hello" 1 1)
+      (ese "oh no" 3 42)))


### PR DESCRIPTION
on error, finish the progress UI and print the error, instead of printing the error into the progress UI. this might result in weird UI when piping bass scripts to each other, but it feels a whole lot cleaner.

also, display a summary of the progress emitted by a thunk in its errors.

overall less repetition/noise and much more helpful information at the bottom of the screen, vs having to snoop around the progress output before to even see the failed command and output.

before:

![image](https://user-images.githubusercontent.com/1880/161898594-e99c9984-01f6-418c-bb88-a2964a2aadcf.png)

after:

![image](https://user-images.githubusercontent.com/1880/161898422-2ed87a7a-3f0b-42af-8e8a-31ecdea9130f.png)
