### PR TITLE
fix lsp test logging location

### DIFF
--- a/pkg/lsp/testdata/config.vim
+++ b/pkg/lsp/testdata/config.vim
@@ -40,7 +40,7 @@ end
 
 configs['bass'] = {
   default_config = {
-    cmd = { 'bass', '--lsp', '--lsp-log-file', 'bass-lsp.log' };
+    cmd = { 'bass', '--lsp', '--lsp-log-file', vim.env.PWD .. '/bass-lsp.log' };
     filetypes = { 'bass' };
     root_dir = function(fname)
       return lspconfig.util.find_git_ancestor(fname)


### PR DESCRIPTION
previously these ended up logging to the `root_dir` because the path was relative; by passing PWD explicitly we can make it absolute

cc @clarafu 