### PR TITLE
add (with-cmd), (thunk-args), Go->Bass (wrap-cmd)

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -647,6 +647,11 @@ func init() {
 		`returns thunk with args set to args`,
 		`=> (with-args (.go) ["test" "./..."])`)
 
+	Ground.Set("with-cmd",
+		Func("with-cmd", "[thunk cmd]", (Thunk).WithCmd),
+		`returns thunk with cmd set to cmd`,
+		`=> (let [inner (with-args (.go) ["build"])] (with-args (with-cmd inner ./wrapped) (cons (thunk-cmd inner) (thunk-args inner))))`)
+
 	Ground.Set("with-stdin",
 		Func("with-stdin", "[thunk vals]", (Thunk).WithStdin),
 		`returns thunk with stdin set to vals`,
@@ -663,12 +668,6 @@ func init() {
 		`The insecure flag determines whether the thunk runs with elevated privileges, and is named to be indicate the reduced security assumptions.`,
 		`=> (with-insecure (.boom) true)`,
 		`=> (= (.boom) (with-insecure (.boom) false))`)
-
-	Ground.Set("wrap-cmd",
-		Func("wrap-cmd", "[thunk cmd & prepend-args]", (Thunk).Wrap),
-		`prepend a run-path + args to a thunk's command`,
-		`Replaces the thunk's run path sets its args to and prepend-args prepended to the original cmd + args.`,
-		`=> (wrap-cmd ($ go test "./...") .strace "-f")`)
 
 	Ground.Set("with-label",
 		Func("with-label", "[thunk name val]", (Thunk).WithLabel),
@@ -688,6 +687,14 @@ func init() {
 		`returns the thunk's command`,
 		`=> (thunk-cmd (.foo))`,
 		`=> (thunk-cmd (./foo))`)
+
+	Ground.Set("thunk-args",
+		Func("thunk-args", "[thunk]", func(thunk Thunk) Value {
+			return NewList(thunk.Args...)
+		}),
+		`returns the thunk's args`,
+		`=> (thunk-args ($ foo abc))`,
+		`=> (thunk-args ($ foo))`)
 
 	Ground.Set("load",
 		Func("load", "[thunk]", func(ctx context.Context, thunk Thunk) (*Scope, error) {

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -152,6 +152,12 @@ func (thunk Thunk) WithImage(image ThunkImage) Thunk {
 	return thunk
 }
 
+// WithArgs sets the thunk's command.
+func (thunk Thunk) WithCmd(cmd ThunkCmd) Thunk {
+	thunk.Cmd = cmd
+	return thunk
+}
+
 // WithArgs sets the thunk's arg values.
 func (thunk Thunk) WithArgs(args []Value) Thunk {
 	thunk.Args = args
@@ -199,13 +205,6 @@ func (thunk Thunk) WithLabel(key Symbol, val Value) Thunk {
 
 	thunk.Labels = thunk.Labels.Copy()
 	thunk.Labels.Set(key, val)
-	return thunk
-}
-
-// Wrap wraps the thunk's cmd + args with an outer cmd and args.
-func (thunk Thunk) Wrap(cmd ThunkCmd, prependArgs ...Value) Thunk {
-	thunk.Args = append(append([]Value{thunk.Cmd.ToValue()}, prependArgs...), thunk.Args...)
-	thunk.Cmd = cmd
 	return thunk
 }
 

--- a/std/run.bass
+++ b/std/run.bass
@@ -69,6 +69,18 @@
 (defn cd [dir thunk & thunks]
   (apply from (cons (with-mount thunk dir ./) thunks)))
 
+; prepend a command + args to a thunk's command + args
+;
+; Replaces the thunk's run path sets its args to and prepend-args prepended to
+; the original cmd + args.
+;
+; => (wrap-cmd ($ go test "./...") .strace "-f")
+(defn wrap-cmd [thunk cmd & args]
+  (-> thunk
+      (with-cmd cmd)
+      (with-args (append args (cons (thunk-cmd thunk)
+                                    (thunk-args thunk))))))
+
 (provide [linux]
   (defn memo-resolve [memos]
     (if (null? memos)


### PR DESCRIPTION
* add `(with-cmd)` for setting a thunk's command, to complete the set with `(with-args)` `(with-stdin)` etc
* add `(thunk-args)` for getting a thunk's args, sibling to `(thunk-cmd)`
* use them to implement `(wrap-cmd)` in Bass instead of Go