### PR TITLE
bump tabs for new gh api

### DIFF
--- a/bass.lock
+++ b/bass.lock
@@ -6,7 +6,7 @@
           "https://github.com/vito/tabs",
           "main"
         ],
-        "output": "1d7aac7df9ffab13c15ff544b6dc7b6397a7304e"
+        "output": "7454c520a8747908ae58936bcb24856b11d9918d"
       }
     ],
     "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=:resolve": [
@@ -78,7 +78,7 @@
           }
         ],
         "output": {
-          "digest": "sha256:652a26d642c82e87b1f7b35b189b408e0a4d6c8706c888e202c7d08591db6926",
+          "digest": "sha256:1a817da48789ac915a6b2819dee5b0f565df01b5ed4c987cd3a22c4a862b0c7c",
           "platform": {
             "os": "linux"
           },

--- a/ci/shipit
+++ b/ci/shipit
@@ -62,17 +62,19 @@
 
 ; creates a release with the given assets
 (defn create-release [src sha tag title]
-  (let [release (project:auth-release (mask *env*:GITHUB_TOKEN :github-token))
+  (let [release (project:release (mask *env*:GITHUB_TOKEN :github-token))
         assets (build-assets src tag)
         pre? (prerelease? tag)]
     (logf "shipping bass @ %s with tag %s" sha tag)
     (release:create!
-      tag sha assets
-      {:title title
-       :generate-notes true
-       :notes-file (project:release-notes src tag)
-       :prerelease pre?
-       :discussion-category (if pre? "" "General")})))
+      tag assets
+      :target sha
+      :title title
+      :generate-notes true
+      :draft true
+      :notes-file (project:release-notes src tag)
+      :prerelease pre?
+      :discussion-category (if pre? "" "General"))))
 
 ; builds and publishes a GitHub release
 ;

--- a/project.bass
+++ b/project.bass
@@ -31,12 +31,12 @@
     (let [notes (string->fs-path (str version ".md"))]
       (undo-wordwrap src (src/notes/ notes)))))
 
-(provide [auth-release]
-  (use (git:github/vito/tabs/ref/main/gh/release))
+(provide [release]
+  (use (git:github/vito/tabs/ref/main/gh))
 
-  ; returns the github release
-  (defn auth-release [token]
-    (release:auth "vito/bass" token)))
+  ; returns the github release module
+  (defn release [token]
+    (gh:release "vito/bass" token)))
 
 (provide [build smoke-test tests docs]
   ; compiles a bass binary for the given platform and puts it in an archive


### PR DESCRIPTION
* gh/release is merged into gh
* release:auth -> gh:release
* use kwargs for release:create!

note that this version of `tabs` depends on #134 and #135 