### PR TITLE
add `--input` (`-i`) flag for passing inputs on stdin

### DIFF
--- a/cmd/bass/export.go
+++ b/cmd/bass/export.go
@@ -19,8 +19,8 @@ func export(ctx context.Context) error {
 	return withProgress(ctx, "export", func(ctx context.Context, vertex *progrock.VertexRecorder) error {
 		dec := bass.NewDecoder(os.Stdin)
 
-		var obj *bass.Scope
-		err := dec.Decode(&obj)
+		var val bass.Value
+		err := dec.Decode(&val)
 		if err != nil {
 			return err
 		}
@@ -28,7 +28,7 @@ func export(ctx context.Context) error {
 		var errs error
 
 		var path bass.ThunkPath
-		err = obj.Decode(&path)
+		err = val.Decode(&path)
 		if err == nil {
 			runtime, err := bass.RuntimeFromContext(ctx, path.Thunk.Platform())
 			if err != nil {
@@ -43,7 +43,7 @@ func export(ctx context.Context) error {
 		}
 
 		var thunk bass.Thunk
-		err = obj.Decode(&thunk)
+		err = val.Decode(&thunk)
 		if err == nil {
 			runtime, err := bass.RuntimeFromContext(ctx, thunk.Platform())
 			if err != nil {

--- a/cmd/bass/main.go
+++ b/cmd/bass/main.go
@@ -19,6 +19,8 @@ import (
 
 var flags = flag.NewFlagSet(os.Args[0], flag.ContinueOnError)
 
+var inputs []string
+
 var runExport bool
 var bumpLock string
 var runPrune bool
@@ -35,6 +37,8 @@ var showVersion bool
 func init() {
 	flags.SetOutput(os.Stdout)
 	flags.SortFlags = false
+
+	flags.StringSliceVarP(&inputs, "input", "i", nil, "inputs to encode as JSON on *stdin*, name=value; value may be a path")
 
 	flags.BoolVarP(&runExport, "export", "e", false, "write a thunk path to stdout as a tar stream, or log the tar contents if stdout is a tty")
 	flags.StringVarP(&bumpLock, "bump", "b", "", "re-generate all values in a bass.lock file")

--- a/cmd/bass/run.go
+++ b/cmd/bass/run.go
@@ -2,11 +2,13 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 
 	"github.com/mattn/go-isatty"
 	"github.com/vito/bass/pkg/bass"
+	"github.com/vito/bass/pkg/cli"
 	"github.com/vito/bass/pkg/runtimes"
 	"github.com/vito/progrock"
 )
@@ -48,9 +50,18 @@ func run(ctx context.Context, filePath string, argv ...string) error {
 
 		env := bass.ImportSystemEnv()
 
+		stdin := bass.Stdin
+		if len(inputs) > 0 {
+			stdin, err = cli.InputsSource(inputs)
+			if err != nil {
+				err = fmt.Errorf("inputs: %w", err)
+				return
+			}
+		}
+
 		scope := runtimes.NewScope(bass.Ground, runtimes.RunState{
 			Dir:    bass.NewHostDir(filepath.Dir(filePath) + string(os.PathSeparator)),
-			Stdin:  bass.Stdin,
+			Stdin:  stdin,
 			Stdout: stdout,
 			Env:    env,
 		})

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -914,7 +914,7 @@ func (plugin *Plugin) renderThunk(thunk bass.Thunk, pathOptional ...bass.Value) 
 	}
 
 	var obj *bass.Scope
-	err = bass.UnmarshalJSON(payload, &obj)
+	err = bass.RawUnmarshalJSON(payload, &obj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -123,13 +123,7 @@ func (path FileOrDirPath) ToValue() Value {
 
 // UnmarshalJSON unmarshals a FilePath or DirPath from JSON.
 func (path *FileOrDirPath) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return path.FromValue(obj)
+	return UnmarshalJSON(payload, path)
 }
 
 func (path FileOrDirPath) MarshalJSON() ([]byte, error) {

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -51,6 +51,12 @@ func ParseFileOrDirPath(arg string) FileOrDirPath {
 	return fod
 }
 
+func IsPathLike(arg string) bool {
+	return strings.HasPrefix(arg, "./") ||
+		strings.HasPrefix(arg, "/") ||
+		strings.HasPrefix(arg, "../")
+}
+
 // FileOrDirPath is an enum type that accepts a FilePath or a DirPath.
 type FileOrDirPath struct {
 	File *FilePath

--- a/pkg/bass/host_path.go
+++ b/pkg/bass/host_path.go
@@ -38,7 +38,7 @@ func (value HostPath) Equal(other Value) bool {
 	var o HostPath
 	return other.Decode(&o) == nil &&
 		value.ContextDir == o.ContextDir &&
-		value.Path == o.Path
+		value.Path.FilesystemPath().Equal(o.Path.FilesystemPath())
 }
 
 func (value HostPath) Decode(dest any) error {

--- a/pkg/bass/json.go
+++ b/pkg/bass/json.go
@@ -6,10 +6,14 @@ import (
 	"io"
 )
 
-func NewDecoder(r io.Reader) *Decoder {
+func NewRawDecoder(r io.Reader) *json.Decoder {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
-	return &Decoder{dec}
+	return dec
+}
+
+func NewDecoder(r io.Reader) *Decoder {
+	return &Decoder{NewRawDecoder(r)}
 }
 
 type Decoder struct {
@@ -37,6 +41,10 @@ func NewEncoder(w io.Writer) *json.Encoder {
 	return enc
 }
 
+func RawUnmarshalJSON(payload []byte, dest any) error {
+	return NewRawDecoder(bytes.NewBuffer(payload)).Decode(dest)
+}
+
 func UnmarshalJSON(payload []byte, dest any) error {
 	return NewDecoder(bytes.NewBuffer(payload)).Decode(dest)
 }
@@ -50,4 +58,46 @@ func MarshalJSON(val any) ([]byte, error) {
 	}
 
 	return bytes.TrimSuffix(buf.Bytes(), []byte{'\n'}), nil
+}
+
+// Descope is a funky little function that decodes from the scope form of a
+// first-class value type, like a thunk path or file path. This typically
+// happens when encoding to and from JSON.
+func Descope(val Value) Value {
+	var thunk Thunk
+	if err := val.Decode(&thunk); err == nil {
+		return thunk
+	}
+
+	var file FilePath
+	if err := val.Decode(&file); err == nil {
+		return file
+	}
+
+	var dir DirPath
+	if err := val.Decode(&dir); err == nil {
+		return dir
+	}
+
+	var cmdp CommandPath
+	if err := val.Decode(&cmdp); err == nil {
+		return cmdp
+	}
+
+	var thunkPath ThunkPath
+	if err := val.Decode(&thunkPath); err == nil {
+		return thunkPath
+	}
+
+	var host HostPath
+	if err := val.Decode(&host); err == nil {
+		return host
+	}
+
+	var secret Secret
+	if err := val.Decode(&secret); err == nil {
+		return secret
+	}
+
+	return val
 }

--- a/pkg/bass/json.go
+++ b/pkg/bass/json.go
@@ -6,10 +6,29 @@ import (
 	"io"
 )
 
-func NewDecoder(r io.Reader) *json.Decoder {
+func NewDecoder(r io.Reader) *Decoder {
 	dec := json.NewDecoder(r)
 	dec.UseNumber()
-	return dec
+	return &Decoder{dec}
+}
+
+type Decoder struct {
+	dec *json.Decoder
+}
+
+func (dec *Decoder) Decode(dest any) error {
+	var any any
+	err := dec.dec.Decode(&any)
+	if err != nil {
+		return err
+	}
+
+	val, err := ValueOf(any)
+	if err != nil {
+		return err
+	}
+
+	return val.Decode(dest)
 }
 
 func NewEncoder(w io.Writer) *json.Encoder {

--- a/pkg/bass/pipes.go
+++ b/pkg/bass/pipes.go
@@ -123,7 +123,7 @@ func (src *InMemorySource) Next(_ context.Context) (Value, error) {
 type JSONSource struct {
 	Name string
 
-	dec *json.Decoder
+	dec *Decoder
 }
 
 var _ PipeSource = (*JSONSource)(nil)
@@ -141,7 +141,7 @@ func (source *JSONSource) String() string {
 }
 
 func (source *JSONSource) Next(context.Context) (Value, error) {
-	var val any
+	var val Value
 	err := source.dec.Decode(&val)
 	if err != nil {
 		if errors.Is(err, io.EOF) {
@@ -151,7 +151,7 @@ func (source *JSONSource) Next(context.Context) (Value, error) {
 		return nil, err
 	}
 
-	return ValueOf(val)
+	return val, nil
 }
 
 type Sink struct {

--- a/pkg/bass/scope.go
+++ b/pkg/bass/scope.go
@@ -247,7 +247,7 @@ func (value *Scope) MarshalJSON() ([]byte, error) {
 
 func (value *Scope) UnmarshalJSON(payload []byte) error {
 	var x map[string]any
-	err := UnmarshalJSON(payload, &x)
+	err := RawUnmarshalJSON(payload, &x)
 	if err != nil {
 		return err
 	}

--- a/pkg/bass/scope.go
+++ b/pkg/bass/scope.go
@@ -246,23 +246,23 @@ func (value *Scope) MarshalJSON() ([]byte, error) {
 }
 
 func (value *Scope) UnmarshalJSON(payload []byte) error {
-	var x any
+	var x map[string]any
 	err := UnmarshalJSON(payload, &x)
 	if err != nil {
 		return err
 	}
 
-	val, err := ValueOf(x)
-	if err != nil {
-		return err
-	}
+	value.Bindings = Bindings{}
 
-	scope, ok := val.(*Scope)
-	if !ok {
-		return fmt.Errorf("expected Object from ValueOf, got %T", val)
-	}
+	for k, v := range x {
+		val, err := ValueOf(v)
+		if err != nil {
+			// TODO: better error
+			return err
+		}
 
-	*value = *scope
+		value.Set(SymbolFromJSONKey(k), Descope(val))
+	}
 
 	return nil
 }

--- a/pkg/bass/secret.go
+++ b/pkg/bass/secret.go
@@ -11,7 +11,7 @@ var Secrets = NewEmptyScope()
 func init() {
 	Ground.Set("mask",
 		Func("mask", "[secret name]", func(val String, name Symbol) Secret {
-			return NewSecret(name, []byte(val))
+			return NewSecret(name.String(), []byte(val))
 		}),
 		`shrouds a string in secrecy`,
 		`Prevents the string from being revealed when the value is displayed.`,
@@ -21,14 +21,14 @@ func init() {
 }
 
 type Secret struct {
-	Name Symbol `json:"secret"`
+	Name string `json:"secret"`
 
 	// private to guard against accidentally revealing it when encoding to JSON
 	// or something
 	secret []byte
 }
 
-func NewSecret(name Symbol, inner []byte) Secret {
+func NewSecret(name string, inner []byte) Secret {
 	return Secret{
 		Name:   name,
 		secret: inner,
@@ -75,4 +75,15 @@ func (value Secret) Decode(dest any) error {
 			Destination: dest,
 		}
 	}
+}
+
+var _ Decodable = (*Secret)(nil)
+
+func (value *Secret) FromValue(val Value) error {
+	var obj *Scope
+	if err := val.Decode(&obj); err != nil {
+		return fmt.Errorf("%T.FromValue: %w", value, err)
+	}
+
+	return decodeStruct(obj, value)
 }

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -77,48 +77,6 @@ func MustThunk(cmd Path, stdin ...Value) Thunk {
 	}
 }
 
-// Descope is a funky little function that decodes from the scope form of a
-// first-class value type, like a thunk path or file path. This typically
-// happens when encoding to and from JSON.
-func Descope(val Value) Value {
-	var thunk Thunk
-	if err := val.Decode(&thunk); err == nil {
-		return thunk
-	}
-
-	var file FilePath
-	if err := val.Decode(&file); err == nil {
-		return file
-	}
-
-	var dir DirPath
-	if err := val.Decode(&dir); err == nil {
-		return dir
-	}
-
-	var cmdp CommandPath
-	if err := val.Decode(&cmdp); err == nil {
-		return cmdp
-	}
-
-	var thunkPath ThunkPath
-	if err := val.Decode(&thunkPath); err == nil {
-		return thunkPath
-	}
-
-	var host HostPath
-	if err := val.Decode(&host); err == nil {
-		return host
-	}
-
-	var secret Secret
-	if err := val.Decode(&secret); err == nil {
-		return secret
-	}
-
-	return val
-}
-
 func (thunk Thunk) Cmdline() string {
 	var cmdline []string
 

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -81,6 +81,11 @@ func MustThunk(cmd Path, stdin ...Value) Thunk {
 // first-class value type, like a thunk path or file path. This typically
 // happens when encoding to and from JSON.
 func Descope(val Value) Value {
+	var thunk Thunk
+	if err := val.Decode(&thunk); err == nil {
+		return thunk
+	}
+
 	var file FilePath
 	if err := val.Decode(&file); err == nil {
 		return file
@@ -130,7 +135,7 @@ func (thunk Thunk) Cmdline() string {
 		if err := arg.Decode(&str); err == nil && !strings.Contains(str, " ") {
 			cmdline = append(cmdline, str)
 		} else {
-			cmdline = append(cmdline, Descope(arg).String())
+			cmdline = append(cmdline, arg.String())
 		}
 	}
 
@@ -307,13 +312,7 @@ func (combiner Thunk) Call(ctx context.Context, val Value, scope *Scope, cont Co
 }
 
 func (thunk *Thunk) UnmarshalJSON(b []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(b, &obj)
-	if err != nil {
-		return err
-	}
-
-	return obj.Decode(thunk)
+	return UnmarshalJSON(b, thunk)
 }
 
 func (thunk *Thunk) Platform() *Platform {

--- a/pkg/bass/thunk_path.go
+++ b/pkg/bass/thunk_path.go
@@ -38,13 +38,7 @@ func (value ThunkPath) Equal(other Value) bool {
 }
 
 func (value *ThunkPath) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return value.FromValue(obj)
+	return UnmarshalJSON(payload, value)
 }
 
 func (value ThunkPath) Decode(dest any) error {

--- a/pkg/bass/thunk_path_test.go
+++ b/pkg/bass/thunk_path_test.go
@@ -27,13 +27,13 @@ func TestThunkPathJSON(t *testing.T) {
 	is.NoErr(err)
 
 	var wlp2 bass.ThunkPath
-	err = json.Unmarshal(payload, &wlp2)
+	err = bass.UnmarshalJSON(payload, &wlp2)
 	is.NoErr(err)
 
 	Equal(t, wlp, wlp2)
 
 	// an empty JSON object must fail on missing keys
-	err = json.Unmarshal([]byte(`{}`), &wlp2)
+	err = bass.UnmarshalJSON([]byte(`{}`), &wlp2)
 	is.True(err != nil)
 }
 

--- a/pkg/bass/thunk_types.go
+++ b/pkg/bass/thunk_types.go
@@ -103,13 +103,7 @@ func (enum ThunkMountSource) ToValue() Value {
 }
 
 func (enum *ThunkMountSource) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return enum.FromValue(obj)
+	return UnmarshalJSON(payload, enum)
 }
 
 func (enum ThunkMountSource) MarshalJSON() ([]byte, error) {
@@ -185,13 +179,7 @@ func (image ThunkImage) ToValue() Value {
 }
 
 func (image *ThunkImage) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return image.FromValue(obj)
+	return UnmarshalJSON(payload, image)
 }
 
 func (image ThunkImage) MarshalJSON() ([]byte, error) {
@@ -257,13 +245,7 @@ func (cmd ThunkCmd) Inner() (Value, error) {
 }
 
 func (path *ThunkCmd) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return path.FromValue(obj)
+	return UnmarshalJSON(payload, path)
 }
 
 func (path ThunkCmd) MarshalJSON() ([]byte, error) {
@@ -344,13 +326,7 @@ func (path ThunkDir) ToValue() Value {
 }
 
 func (path *ThunkDir) UnmarshalJSON(payload []byte) error {
-	var obj *Scope
-	err := UnmarshalJSON(payload, &obj)
-	if err != nil {
-		return err
-	}
-
-	return path.FromValue(obj)
+	return UnmarshalJSON(payload, path)
 }
 
 func (path ThunkDir) MarshalJSON() ([]byte, error) {

--- a/pkg/bass/value.go
+++ b/pkg/bass/value.go
@@ -73,10 +73,10 @@ func ValueOf(src any) (Value, error) {
 				return nil, err
 			}
 
-			scope.Set(SymbolFromJSONKey(k), val)
+			scope.Set(SymbolFromJSONKey(k), Descope(val))
 		}
 
-		return scope, nil
+		return Descope(scope), nil
 	case map[any]any:
 		scope := NewEmptyScope()
 		for k, v := range x {
@@ -91,10 +91,10 @@ func ValueOf(src any) (Value, error) {
 				return nil, err
 			}
 
-			scope.Set(SymbolFromJSONKey(s), val)
+			scope.Set(SymbolFromJSONKey(s), Descope(val))
 		}
 
-		return scope, nil
+		return Descope(scope), nil
 	default:
 		rt := reflect.TypeOf(src)
 		rv := reflect.ValueOf(src)

--- a/pkg/bass/value_test.go
+++ b/pkg/bass/value_test.go
@@ -51,7 +51,7 @@ var allConstValues = []bass.Value{
 			Dir: &bass.DirPath{"dir"},
 		},
 	},
-	bass.NewSecret(bass.Symbol("bruces-secret"), []byte("im always angry")),
+	bass.NewSecret("bruces-secret", []byte("im always angry")),
 }
 
 var exprValues = []bass.Value{

--- a/pkg/cli/inputs.go
+++ b/pkg/cli/inputs.go
@@ -1,0 +1,40 @@
+package cli
+
+import (
+	"bytes"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/vito/bass/pkg/bass"
+)
+
+func InputsSource(inputs []string) (*bass.Source, error) {
+	bindings := bass.Bindings{}
+	for _, input := range inputs {
+		var val bass.Value
+
+		name, arg, ok := strings.Cut(input, "=")
+		if !ok {
+			val = bass.Bool(true)
+		} else if bass.IsPathLike(arg) {
+			dir, base := path.Split(arg)
+			if base == "" {
+				base = "."
+			}
+
+			val = bass.NewHostPath(filepath.FromSlash(path.Clean(dir)), bass.ParseFileOrDirPath(base))
+		} else {
+			val = bass.String(arg)
+		}
+
+		bindings[bass.Symbol(name)] = val
+	}
+
+	inputJSON, err := bass.MarshalJSON(bindings.Scope())
+	if err != nil {
+		return nil, err
+	}
+
+	return bass.NewSource(bass.NewJSONSource("inputs", bytes.NewBuffer(inputJSON))), nil
+}

--- a/pkg/cli/inputs_test.go
+++ b/pkg/cli/inputs_test.go
@@ -1,0 +1,78 @@
+package cli_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/vito/bass/pkg/bass"
+	"github.com/vito/bass/pkg/basstest"
+	"github.com/vito/bass/pkg/cli"
+	"github.com/vito/is"
+)
+
+func TestInputsSource(t *testing.T) {
+	for _, example := range []struct {
+		Inputs []string
+		Value  bass.Value
+	}{
+		{[]string{"bool"}, bass.Bindings{
+			"bool": bass.Bool(true),
+		}.Scope()},
+		{[]string{"str=abc"}, bass.Bindings{
+			"str": bass.String("abc"),
+		}.Scope()},
+		{[]string{"str=abc"}, bass.Bindings{
+			"str": bass.String("abc"),
+		}.Scope()},
+		{[]string{"bool", "str=abc"}, bass.Bindings{
+			"bool": bass.Bool(true),
+			"str":  bass.String("abc")}.Scope(),
+		},
+		{[]string{"path=./"}, bass.Bindings{
+			"path": bass.NewHostPath(".", bass.ParseFileOrDirPath(".")),
+		}.Scope()},
+		{[]string{"notpath=."}, bass.Bindings{
+			"notpath": bass.String("."),
+		}.Scope()},
+		{[]string{"path=/absolute"}, bass.Bindings{
+			"path": bass.NewHostPath("/", bass.ParseFileOrDirPath("absolute")),
+		}.Scope()},
+		{[]string{"path=/absolute/file"}, bass.Bindings{
+			"path": bass.NewHostPath("/absolute", bass.ParseFileOrDirPath("file")),
+		}.Scope()},
+		{[]string{"path=/absolute/dir/"}, bass.Bindings{
+			"path": bass.NewHostPath("/absolute/dir", bass.ParseFileOrDirPath(".")),
+		}.Scope()},
+		{[]string{"path=/absolute/dir/"}, bass.Bindings{
+			"path": bass.NewHostPath("/absolute/dir", bass.ParseFileOrDirPath(".")),
+		}.Scope()},
+		{[]string{"path=./relative/dir/"}, bass.Bindings{
+			"path": bass.NewHostPath("relative/dir", bass.ParseFileOrDirPath(".")),
+		}.Scope()},
+		{[]string{"path=./relative/file"}, bass.Bindings{
+			"path": bass.NewHostPath("relative", bass.ParseFileOrDirPath("file")),
+		}.Scope()},
+		{[]string{"notpath=ambiguous/path/"}, bass.Bindings{
+			"notpath": bass.String("ambiguous/path/"),
+		}.Scope()},
+		{[]string{"notpath=ambiguous/path"}, bass.Bindings{
+			"notpath": bass.String("ambiguous/path"),
+		}.Scope()},
+		{[]string{"uri=http://example.com/"}, bass.Bindings{
+			"uri": bass.String("http://example.com/"),
+		}.Scope()},
+	} {
+		t.Run(fmt.Sprintf("%q", example.Inputs), func(t *testing.T) {
+			is := is.New(t)
+
+			source, err := cli.InputsSource(example.Inputs)
+			is.NoErr(err)
+
+			val, err := source.PipeSource.Next(context.TODO())
+			is.NoErr(err)
+
+			basstest.Equal(t, example.Value, val)
+		})
+	}
+}

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -788,7 +788,7 @@ func (b *builder) initializeMount(ctx context.Context, source bass.ThunkMountSou
 	}
 
 	if source.Secret != nil {
-		id := source.Secret.Name.String()
+		id := source.Secret.Name
 		b.secrets[id] = source.Secret.Reveal()
 		return llb.AddSecret(targetPath, llb.SecretID(id)), "", false, nil
 	}


### PR DESCRIPTION
Inputs can be passed as key-value pairs fed as JSON on `*stdin*`. Paths are parsed into host paths, which must start with `./` or `/` regardless of your local platform's slash preferences.

```sh
$ ./build -i src=./ -i os=linux
```

```clojure
(next *stdin*) ; => {:src <host: ./> :os "linux"}
```

This approach should let us get pretty far without having to implement full-blown flag parsing where we'd also have to figure out how to represent rich objects like thunk paths in someplace that only takes strings. Here we can just encode them as JSON.

I think passing objects on stdin is generally preferable to flags/argv in an automation scenario, but it sucks for interactive use (no one wants to type JSON), hence `--input/-i` for passing values instead. This approach maximizes reusability of scripts between interactive dev shells, CI hooks, and/or being called from other Bass scripts:

```clojure
(run (*dir*/build {:src src :os "linux"}))
```

Someday we could support omitting the braces for keyword arg like UX.