### PR TITLE
swap bind destructuring order: `{foo :foo}` -> `{:foo foo}`

### DIFF
--- a/bass/actions
+++ b/bass/actions
@@ -3,7 +3,7 @@
 (use (*dir*/../project))
 
 (defn main []
-  (for [{sha :sha} *stdin*]
+  (for [{:sha sha} *stdin*]
     (let [src (project:checkout sha)]
       (run (*dir*/test {:src src}))
       (run (*dir*/nix-check {:src src})))))

--- a/bass/build
+++ b/bass/build
@@ -1,10 +1,10 @@
 #!/usr/bin/env bass
 
 (defn main []
-  (for [{src :src
-         version (:version "dev")
-         os (:os "linux")
-         arch (:arch "amd64")} *stdin*]
+  (for [{:src src
+         (:version "dev") version
+         (:os "linux") os
+         (:arch "amd64") arch} *stdin*]
     (use (src/project))
     (logf "building and smoke-testing %s" src)
     (let [dist (project:build src version os arch)]

--- a/bass/docs
+++ b/bass/docs
@@ -1,9 +1,6 @@
 #!/usr/bin/env bass
 
 (defn main []
-  (for [{src :src
-         version (:version "dev")
-         os (:os "linux")
-         arch (:arch "amd64")} *stdin*]
+  (for [{:src src} *stdin*]
     (use (src/project))
     (emit (project:docs src) *stdout*)))

--- a/bass/nix-check
+++ b/bass/nix-check
@@ -1,7 +1,7 @@
 #!/usr/bin/env bass
 
 (defn main testflags
-  (for [{src :src} *stdin*]
+  (for [{:src src} *stdin*]
     (use (src/project))
     (log "running nix-check")
     (run (project:nix-checks src))))

--- a/bass/shipit
+++ b/bass/shipit
@@ -9,9 +9,9 @@
 ; Needs the tag to checkout, build, and publish along with a title for the
 ; release.
 (defn main []
-  (for [{sha :sha
-         tag :tag
-         title (:title tag)} *stdin*]
+  (for [{:sha sha
+         :tag tag
+         (:title tag) title} *stdin*]
     (let [src (project:checkout sha)
           release-url (create-release src sha tag title)]
       (logf "release published to %s" release-url))))

--- a/bass/test
+++ b/bass/test
@@ -1,7 +1,7 @@
 #!/usr/bin/env bass
 
 (defn main testflags
-  (for [{src :src} *stdin*]
+  (for [{:src src} *stdin*]
     (use (src/project))
     (log "running tests")
     (run (project:tests src ["./..." & testflags]))))

--- a/pkg/bass/bind.go
+++ b/pkg/bass/bind.go
@@ -90,7 +90,7 @@ func (bind Bind) Bind(ctx context.Context, bindScope *Scope, cont Cont, val Valu
 		return cont.Call(bind, nil)
 	}
 
-	vb, vf, rest := bind[0], bind[1], bind[2:]
+	vf, vb, rest := bind[0], bind[1], bind[2:]
 
 	var valBinding Bindable
 	if err := vb.Decode(&valBinding); err != nil {
@@ -98,10 +98,10 @@ func (bind Bind) Bind(ctx context.Context, bindScope *Scope, cont Cont, val Valu
 	}
 
 	var kw Keyword
-	var valFromWithDefault List
+	var kwWithDefault List
 	var valDefault Value
-	if err := vf.Decode(&valFromWithDefault); err == nil {
-		vals, err := ToSlice(valFromWithDefault)
+	if err := vf.Decode(&kwWithDefault); err == nil {
+		vals, err := ToSlice(kwWithDefault)
 		if err != nil {
 			return cont.Call(nil, err)
 		}

--- a/pkg/bass/binding_test.go
+++ b/pkg/bass/binding_test.go
@@ -279,8 +279,8 @@ func TestBinding(t *testing.T) {
 		{
 			Name: "binding bind",
 			Bindable: bass.Bind{
-				bass.Symbol("foo-bnd"), bass.Keyword("foo"),
-				bass.Symbol("bar-bnd"), bass.Keyword("bar"),
+				bass.Keyword("foo"), bass.Symbol("foo-bnd"),
+				bass.Keyword("bar"), bass.Symbol("bar-bnd"),
 			},
 			Value: bass.Bindings{
 				"foo": bass.Bool(true),
@@ -294,8 +294,8 @@ func TestBinding(t *testing.T) {
 		{
 			Name: "binding bind unbound",
 			Bindable: bass.Bind{
-				bass.Symbol("foo-bnd"), bass.Keyword("foo"),
-				bass.Symbol("bar-bnd"), bass.Keyword("bar"),
+				bass.Keyword("foo"), bass.Symbol("foo-bnd"),
+				bass.Keyword("bar"), bass.Symbol("bar-bnd"),
 			},
 			Value: bass.Bindings{
 				"bar": bass.Int(42),
@@ -310,7 +310,7 @@ func TestBinding(t *testing.T) {
 		{
 			Name: "binding bind mismatch",
 			Bindable: bass.Bind{
-				bass.Symbol("foo-bnd"), bass.Keyword("foo"),
+				bass.Keyword("foo"), bass.Symbol("foo-bnd"),
 				bass.Symbol("bar-bnd"),
 			},
 			Value: bass.Bindings{
@@ -321,8 +321,8 @@ func TestBinding(t *testing.T) {
 		{
 			Name: "binding bind default",
 			Bindable: bass.Bind{
-				bass.Symbol("foo-bnd"), bass.NewList(bass.Keyword("foo"), bass.Symbol("sentinel")),
-				bass.Symbol("bar-bnd"), bass.Keyword("bar"),
+				bass.NewList(bass.Keyword("foo"), bass.Symbol("sentinel")), bass.Symbol("foo-bnd"),
+				bass.Keyword("bar"), bass.Symbol("bar-bnd"),
 			},
 			Value: bass.Bindings{
 				"bar": bass.Int(42),


### PR DESCRIPTION
much easier to read (imo) for deeply nested destructuring

* top: no destructuring
* middle: clojure-style (current)
* bottom: reversed (this PR)

![image](https://user-images.githubusercontent.com/1880/166180832-afe79a0d-8313-4f8f-949f-d960baf235cc.png)

note: Clojure needed to swap them to disambiguate `:keys`, `:as`, etc. - but Bass eschews those, so it can just use the conventional syntax