### PR TITLE
synchronize cache access by default

### DIFF
--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -783,7 +783,7 @@ func (b *builder) initializeMount(ctx context.Context, source bass.ThunkMountSou
 		return llb.AddMount(
 			targetPath,
 			llb.Scratch(),
-			llb.AsPersistentCacheDir(source.Cache.String(), llb.CacheMountShared),
+			llb.AsPersistentCacheDir(source.Cache.String(), llb.CacheMountLocked),
 		), "", false, nil
 	}
 

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -132,6 +132,21 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 			Result: bass.NewList(bass.Int(1), bass.Int(2), bass.Int(3)),
 		},
 		{
+			File: "cache-sync.bass",
+			Result: bass.NewList(
+				bass.NewList(bass.String("1")),
+				bass.NewList(bass.String("2")),
+				bass.NewList(bass.String("3")),
+				bass.NewList(bass.String("4")),
+				bass.NewList(bass.String("5")),
+				bass.NewList(bass.String("6")),
+				bass.NewList(bass.String("7")),
+				bass.NewList(bass.String("8")),
+				bass.NewList(bass.String("9")),
+				bass.NewList(bass.String("10")),
+			),
+		},
+		{
 			File:   "read-path.bass",
 			Result: bass.String("hello, world!\n"),
 		},

--- a/pkg/runtimes/testdata/cache-sync.bass
+++ b/pkg/runtimes/testdata/cache-sync.bass
@@ -1,0 +1,26 @@
+(def *memos* *dir*/memos.json)
+
+(def test-cache-path
+  (subpath /test/sync-counter/ (string->fs-path (str (now 0)))))
+
+(defn counter [tag]
+  (subpath
+    (from (linux/alpine)
+      (-> ($ sh -c "echo x >> /var/cache/file; cat /var/cache/file | wc -l > count")
+          (with-label :tag tag)
+          (with-mount test-cache-path /var/cache/)))
+    ./count))
+
+(defn all [stream]
+  (case (next stream :eof)
+    :eof []
+    val (cons val (all stream))))
+
+(defn counts tags
+  (let [files (map counter tags)]
+    (-> ($ sh -c "cat $@ | sort -n" ignored & $files)
+        (with-image (linux/alpine))
+        (read :unix-table)
+        all)))
+
+(counts "a" "b" "c" "d" "e" "f" "g" "h" "i" "j")


### PR DESCRIPTION
I kept running into spurious failures with e.g. `"nix" executable not found` when builds ran concurrently for the first time.

The setting was `shared` which is basically "yolo" - everyone gets write access.

An alternative is `private` which gives each writer their own copy, and I suppose last writer wins?

The most conservative option is `locked` which ensures only one writer has access at a time, setting the others to wait.

I'm sticking with it until someone complains. :)