### PR TITLE
add `(start)` primitive beneath `(run)` and `(succeeds?)`

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -28,27 +28,6 @@ func NewStandardScope() *Scope {
 func init() {
 	Ground.Name = "ground"
 
-	Ground.Set("go",
-		Op("go", "body", func(ctx context.Context, cont Cont, scope *Scope, body ...Value) ReadyCont {
-			// each goroutine must have its own stack
-			ctx = ForkTrace(ctx)
-
-			var res Value
-			var err error
-
-			wg := new(sync.WaitGroup)
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				res, err = Trampoline(ctx, do(ctx, Identity, NewEmptyScope(scope), body))
-			}()
-
-			return cont.Call(Func("wait", "[]", func() (Value, error) {
-				wg.Wait()
-				return res, err
-			}), nil)
-		}))
-
 	Ground.Set("def",
 		Op("def", "[binding value]", func(ctx context.Context, cont Cont, scope *Scope, formals Bindable, val Value) ReadyCont {
 			return val.Eval(ctx, scope, Continue(func(res Value) Value {
@@ -766,6 +745,41 @@ func init() {
 		`Raises an error if the thunk's command fails (i.e. 0 exit code).`,
 		`Returns null.`,
 		`=> (run (from (linux/alpine) ($ echo "Hello, world!")))`)
+
+	Ground.Set("start",
+		Func("start", "[thunk handler]", func(ctx context.Context, thunk Thunk, handler Combiner) error {
+			// each goroutine must have its own stack
+			ctx = ForkTrace(ctx)
+
+			runtime, err := RuntimeFromContext(ctx, thunk.Platform())
+			if err != nil {
+				return err
+			}
+
+			logger := zapctx.FromContext(ctx).With(
+				zap.String("thunk", thunk.Name()),
+				zap.String("cmdline", thunk.Cmdline()),
+			)
+
+			wg := new(sync.WaitGroup)
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				err := runtime.Run(ctx, io.Discard, thunk)
+				if err != nil {
+					logger.Error("start: run failed", zap.Error(err))
+				}
+
+				ok := err == nil
+
+				_, err = Trampoline(ctx, handler.Call(ctx, NewList(Bool(ok)), NewEmptyScope(), Identity))
+				if err != nil {
+					logger.Error("start: handler failed", zap.Error(err), zap.Bool("ok", ok))
+				}
+			}()
+
+			return nil
+		}))
 
 	Ground.Set("succeeds?",
 		Func("succeeds?", "[thunk]", func(ctx context.Context, thunk Thunk) (bool, error) {

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -747,19 +747,21 @@ func init() {
 		`=> (run (from (linux/alpine) ($ echo "Hello, world!")))`)
 
 	Ground.Set("start",
-		Func("start", "[thunk handler]", func(ctx context.Context, thunk Thunk, handler Combiner) error {
+		Func("start", "[thunk handler]", func(ctx context.Context, thunk Thunk, handler Combiner) (Combiner, error) {
 			// each goroutine must have its own stack
 			ctx = ForkTrace(ctx)
 
 			runtime, err := RuntimeFromContext(ctx, thunk.Platform())
 			if err != nil {
-				return err
+				return nil, err
 			}
 
 			logger := zapctx.FromContext(ctx).With(
 				zap.String("thunk", thunk.Name()),
 				zap.String("cmdline", thunk.Cmdline()),
 			)
+
+			var res Value
 
 			wg := new(sync.WaitGroup)
 			wg.Add(1)
@@ -772,13 +774,16 @@ func init() {
 
 				ok := err == nil
 
-				_, err = Trampoline(ctx, handler.Call(ctx, NewList(Bool(ok)), NewEmptyScope(), Identity))
+				res, err = Trampoline(ctx, handler.Call(ctx, NewList(Bool(ok)), NewEmptyScope(), Identity))
 				if err != nil {
 					logger.Error("start: handler failed", zap.Error(err), zap.Bool("ok", ok))
 				}
 			}()
 
-			return nil
+			return Func("wait", "[]", func() (Value, error) {
+				wg.Wait()
+				return res, err
+			}), nil
 		}))
 
 	Ground.Set("succeeds?",

--- a/pkg/bass/trace.go
+++ b/pkg/bass/trace.go
@@ -76,6 +76,17 @@ func WithTrace(ctx context.Context, trace *Trace) context.Context {
 	return context.WithValue(ctx, traceKey{}, trace)
 }
 
+func ForkTrace(ctx context.Context) context.Context {
+	if trace, ok := TraceFrom(ctx); ok {
+		cp := &Trace{}
+		copy(cp.frames[:], trace.frames[:])
+		cp.depth = trace.depth
+		return context.WithValue(ctx, traceKey{}, cp)
+	}
+
+	return ctx
+}
+
 func TraceFrom(ctx context.Context) (*Trace, bool) {
 	trace := ctx.Value(traceKey{})
 	if trace != nil {

--- a/std/root.bass
+++ b/std/root.bass
@@ -452,6 +452,13 @@
 ; => (((id id) id) id)
 (defn id [x] x)
 
+; returns a function ignores its argument and returns x
+;
+; => ((always 42) :never)
+;
+; => (((always always) :never) :never)
+(defn always [x] (fn [_] x))
+
 ; collects the values from a scope
 ;
 ; => (vals {:a 1 :b 2})
@@ -503,3 +510,26 @@
   ^:indent
   (defop curryfn [args & body] scope
     (eval (curry args body) scope)))
+
+; returns true if the thunk successfully runs (i.e. exit code 0)
+;
+; returns false if it fails (i.e. exit code nonzero)
+;
+; Used for running a thunk as a conditional instead of erroring when it fails.
+;
+; => (succeeds? (from (linux/alpine) (.false)))
+;
+; => (succeeds? (from (linux/alpine) (.true)))
+(defn succeeds? [thunk]
+  ((start thunk id)))
+
+; runs a thunk
+;
+; Raises an error if the thunk's command fails (i.e. exit code 0)
+;
+; Returns null.
+;
+; => (run (from (linux/alpine) ($ echo "Hello, world!")))
+(defn run [thunk]
+  ((start thunk
+          (fn [ok?] (if ok? null (error (str thunk)))))))


### PR DESCRIPTION
* takes a thunk and a callback function
* runs the thunk concurrently
* calls the callback with a boolean indicating success or failure
* returns a function which can be called to wait for the thunk and return the result of the callback

so `(succeeds? thunk)` is implemented as `((start thunk id))`

when the callback returns an error, the underlying error will be tacked on to the end; that way `(run)` can wrap the error with a higher-level message, while preserving the lower-level details