### PR TITLE
structured logs and errors, remove (logf) and (errorf)

### DIFF
--- a/bass/build
+++ b/bass/build
@@ -6,7 +6,7 @@
          (:os "linux") os
          (:arch "amd64") arch} *stdin*]
     (use (src/project))
-    (logf "building and smoke-testing %s" src)
+    (log "building + smoke-testing" :source src :version version :os os :arch arch)
     (let [dist (project:build src version os arch)]
       (project:smoke-test dist)
       (emit dist *stdout*))))

--- a/bass/shipit
+++ b/bass/shipit
@@ -14,7 +14,7 @@
          (:title tag) title} *stdin*]
     (let [src (project:checkout sha)
           release-url (create-release src sha tag title)]
-      (logf "release published to %s" release-url))))
+      (log "release published" :release release-url))))
 
 ; all supported os and architectures supported by bass
 ;
@@ -78,7 +78,7 @@
         assets (build-assets src tag)
         draft false
         pre? (prerelease? tag)]
-    (logf "shipping bass @ %s with tag %s" sha tag)
+    (log "shipping!" :sha sha :tag tag)
     (release:create!
       tag assets
       :target sha

--- a/demos/booklit/test-last-10.bass
+++ b/demos/booklit/test-last-10.bass
@@ -11,5 +11,5 @@
         (read :unix-table))
     (fn [[sha]]
       (let [src (git:github/vito/booklit/sha/ (string->dir sha))]
-        (logf "running tests for %s" sha)
+        (log "running tests" :sha sha)
         (run (project:tests src testflags))))))

--- a/demos/speedtest.bass
+++ b/demos/speedtest.bass
@@ -12,4 +12,4 @@
 
 (defn main []
   (let [results (next (read (speedtest) :json))]
-    (logf "speedtest result: %s" results:result:url)))
+    (log "speedtest complete" :result-url results:result:url)))

--- a/pkg/bass/cons.go
+++ b/pkg/bass/cons.go
@@ -1,6 +1,10 @@
 package bass
 
-import "context"
+import (
+	"context"
+
+	"go.uber.org/zap/zapcore"
+)
 
 type Cons Pair
 
@@ -63,6 +67,9 @@ func (value Cons) Decode(dest any) error {
 	case *Bindable:
 		*x = value
 		return nil
+	case *zapcore.ArrayMarshaler:
+		*x = value
+		return nil
 	default:
 		return DecodeError{
 			Source:      value,
@@ -103,4 +110,10 @@ func (binding Cons) Bind(ctx context.Context, scope *Scope, cont Cont, value Val
 
 func (binding Cons) EachBinding(cb func(Symbol, Range) error) error {
 	return EachBindingList(binding, cb)
+}
+
+var _ zapcore.ArrayMarshaler = Empty{}
+
+func (cons Cons) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	return EncodeList(cons, enc)
 }

--- a/pkg/bass/empty.go
+++ b/pkg/bass/empty.go
@@ -2,6 +2,8 @@ package bass
 
 import (
 	"context"
+
+	"go.uber.org/zap/zapcore"
 )
 
 type Empty struct{}
@@ -43,6 +45,9 @@ func (value Empty) Decode(dest any) error {
 	case *Bindable:
 		*x = value
 		return nil
+	case *zapcore.ArrayMarshaler:
+		*x = value
+		return nil
 	}
 
 	return decodeSlice(value, dest)
@@ -68,5 +73,11 @@ func (binding Empty) Bind(_ context.Context, _ *Scope, cont Cont, val Value, _ .
 }
 
 func (Empty) EachBinding(func(Symbol, Range) error) error {
+	return nil
+}
+
+var _ zapcore.ArrayMarshaler = Empty{}
+
+func (Empty) MarshalLogArray(enc zapcore.ArrayEncoder) error {
 	return nil
 }

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -133,6 +133,13 @@ func init() {
 		`=> (log "hello, world!")`,
 		`=> (log "doing something" :a 1 :since {:day 1})`)
 
+	Ground.Set("error",
+		Func("error", "[msg]", NewError),
+		`errors with the given message`,
+		`Accepts key-value fields.`,
+		`=> (error "oh no!")`,
+		`=> (error "oh no!" :exit-code 2)`)
+
 	Ground.Set("now",
 		Func("now", "[seconds]", func(duration int) string {
 			return Clock.Now().Truncate(time.Duration(duration) * time.Second).UTC().Format(time.RFC3339)
@@ -140,11 +147,6 @@ func init() {
 		`returns the current UTC time truncated to the given seconds`,
 		`Typically used to influence caching for thunks whose result may change over time.`,
 		`=> (now 60)`)
-
-	Ground.Set("error",
-		Func("error", "[msg]", NewError),
-		`errors with the given message`,
-		`=> (error "oh no!")`)
 
 	Ground.Set("do",
 		Op("do", "body", func(ctx context.Context, cont Cont, scope *Scope, body ...Value) ReadyCont {

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -133,14 +133,6 @@ func init() {
 		`=> (log "hello, world!")`,
 		`=> (log "doing something" a: 1 since: {:day 1})`)
 
-	Ground.Set("logf",
-		Func("logf", "[fmt & args]", func(ctx context.Context, msg string, args ...Value) {
-			zapctx.FromContext(ctx).Sugar().Infof(msg, fmtArgs(args...)...)
-		}),
-		`logs a message formatted with the given values`,
-		`Passes straight through to Go's fmt package.`,
-		`=> (logf "%d days until 2022" 0)`)
-
 	Ground.Set("now",
 		Func("now", "[seconds]", func(duration int) string {
 			return Clock.Now().Truncate(time.Duration(duration) * time.Second).UTC().Format(time.RFC3339)

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -142,7 +142,7 @@ func init() {
 		`=> (now 60)`)
 
 	Ground.Set("error",
-		Func("error", "[msg]", errors.New),
+		Func("error", "[msg]", NewError),
 		`errors with the given message`,
 		`=> (error "oh no!")`)
 

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -131,7 +131,7 @@ func init() {
 		`Returns the given value.`,
 		`Accepts key-value fields for structured logging.`,
 		`=> (log "hello, world!")`,
-		`=> (log "doing something" a: 1 since: {:day 1})`)
+		`=> (log "doing something" :a 1 :since {:day 1})`)
 
 	Ground.Set("now",
 		Func("now", "[seconds]", func(duration int) string {

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jonboulle/clockwork"
 	"github.com/vito/bass/pkg/ioctx"
 	"github.com/vito/bass/pkg/zapctx"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 // Ground is the scope providing the standard library.
@@ -94,19 +96,42 @@ func init() {
 		`=> (json {:foo-bar "baz"})`)
 
 	Ground.Set("log",
-		Func("log", "[val]", func(ctx context.Context, v Value) Value {
-			var msg string
-			if err := v.Decode(&msg); err == nil {
-				zapctx.FromContext(ctx).Info(msg)
-			} else {
-				zapctx.FromContext(ctx).Info(v.String())
+		Func("log", "[val & kwargs]", func(ctx context.Context, v Value, kv ...Value) (Value, error) {
+			logger := zapctx.FromContext(ctx)
+
+			if len(kv) > 0 {
+				fields, err := Assoc(NewEmptyScope(), kv...)
+				if err != nil {
+					return nil, err
+				}
+
+				err = fields.Each(func(k Symbol, v Value) error {
+					f, err := zapField(k, v)
+					if err != nil {
+						return err
+					}
+					logger = logger.With(f)
+					return nil
+				})
+				if err != nil {
+					return nil, err
+				}
 			}
 
-			return v
+			var msg string
+			if err := v.Decode(&msg); err == nil {
+				logger.Info(msg)
+			} else {
+				logger.Info(v.String())
+			}
+
+			return v, nil
 		}),
 		`logs a string message or arbitrary value to stderr`,
 		`Returns the given value.`,
-		`=> (log "hello, world!")`)
+		`Accepts additional key-value fields for structured logging.`,
+		`=> (log "hello, world!")`,
+		`=> (log "doing something" a: 1 since: {:day 1})`)
 
 	Ground.Set("logf",
 		Func("logf", "[fmt & args]", func(ctx context.Context, msg string, args ...Value) {
@@ -462,32 +487,7 @@ func init() {
 	)
 
 	Ground.Set("assoc",
-		Func("assoc", "[obj & kvs]", func(obj *Scope, kv ...Value) (*Scope, error) {
-			clone := obj.Copy()
-
-			var k Symbol
-			var v Value
-			for i := 0; i < len(kv); i++ {
-				if i%2 == 0 {
-					err := kv[i].Decode(&k)
-					if err != nil {
-						return nil, err
-					}
-				} else {
-					err := kv[i].Decode(&v)
-					if err != nil {
-						return nil, err
-					}
-
-					clone.Set(k, v)
-
-					k = ""
-					v = nil
-				}
-			}
-
-			return clone, nil
-		}),
+		Func("assoc", "[obj & kvs]", Assoc),
 		`assoc[iate] keys with values in a clone of a scope`,
 		`Takes a scope and a flat pair sequence alternating symbols and values.`,
 		`Returns a clone of the scope with the symbols fields set to their associated value.`,
@@ -1028,4 +1028,27 @@ func do(ctx context.Context, cont Cont, scope *Scope, body []Value) ReadyCont {
 	}
 
 	return body[0].Eval(ctx, scope, next)
+}
+
+func zapField(k Symbol, v Value) (zap.Field, error) {
+	name := k.String()
+
+	var str string
+	var num int
+	var bol bool
+	var am zapcore.ArrayMarshaler
+	var om zapcore.ObjectMarshaler
+	if v.Decode(&str) == nil {
+		return zap.String(name, str), nil
+	} else if v.Decode(&num) == nil {
+		return zap.Int(name, num), nil
+	} else if v.Decode(&bol) == nil {
+		return zap.Bool(name, bol), nil
+	} else if v.Decode(&am) == nil {
+		return zap.Array(name, am), nil
+	} else if v.Decode(&om) == nil {
+		return zap.Object(name, om), nil
+	}
+
+	return zap.Field{}, EncodeError{v}
 }

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -146,13 +146,6 @@ func init() {
 		`errors with the given message`,
 		`=> (error "oh no!")`)
 
-	Ground.Set("errorf",
-		Func("errorf", "[fmt & args]", func(msg string, args ...Value) error {
-			return fmt.Errorf(msg, fmtArgs(args...)...)
-		}),
-		`errors with a message formatted with the given values`,
-		`=> (errorf "uh oh: %s" "it broke")`)
-
 	Ground.Set("do",
 		Op("do", "body", func(ctx context.Context, cont Cont, scope *Scope, body ...Value) ReadyCont {
 			return do(ctx, cont, scope, body)

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -129,7 +129,7 @@ func init() {
 		}),
 		`logs a string message or arbitrary value to stderr`,
 		`Returns the given value.`,
-		`Accepts additional key-value fields for structured logging.`,
+		`Accepts key-value fields for structured logging.`,
 		`=> (log "hello, world!")`,
 		`=> (log "doing something" a: 1 since: {:day 1})`)
 

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -783,7 +783,16 @@ func TestGroundConstructors(t *testing.T) {
 		{
 			Name:     "error",
 			Bass:     `(error "oh no!")`,
-			ErrEqual: errors.New("oh no!"),
+			ErrEqual: bass.NewError("oh no!"),
+		},
+		{
+			Name: "error with fields",
+			Bass: `(error "oh no!" :a 1 :since {:day 1})`,
+			ErrEqual: bass.NewError(
+				"oh no!",
+				bass.Symbol("a"), bass.Int(1),
+				bass.Symbol("since"), bass.Bindings{"day": bass.Int(1)}.Scope(),
+			),
 		},
 		{
 			Name:     "errorf",
@@ -2009,9 +2018,14 @@ func TestGroundCase(t *testing.T) {
 			Result: bass.Symbol("more"),
 		},
 		{
-			Name:     "case matching none",
-			Bass:     "(case 3 1 :one 2 :two)",
-			ErrEqual: fmt.Errorf("no matching case branch for 3"),
+			Name: "case matching none",
+			Bass: "(case 3 1 :one 2 :two)",
+			ErrEqual: &bass.StructuredError{
+				Message: "no matching case branch",
+				Fields: bass.Bindings{
+					"target": bass.Int(3),
+				}.Scope(),
+			},
 		},
 		{
 			Name:   "case binding",

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -181,7 +181,9 @@ func (example BasicExample) Run(t *testing.T) {
 			for i, l := range example.Log {
 				logRe, err := regexp.Compile(l)
 				is.NoErr(err)
-				is.True(logRe.MatchString(lines[i]))
+				if !logRe.MatchString(lines[i]) {
+					t.Errorf("%q does not match %q", lines[i], logRe)
+				}
 			}
 		}
 	})
@@ -1967,16 +1969,22 @@ func TestGroundDebug(t *testing.T) {
 			Log:    []string{"INFO\thello"},
 		},
 		{
+			Name:   "log with fields",
+			Bass:   `(log "hello" :a 1 :b true)`,
+			Result: bass.String("hello"),
+			Log:    []string{"INFO\thello\t{\"a\": 1, \"b\": true}"},
+		},
+		{
 			Name:   "log non-string",
 			Bass:   `(log {:a 1 :b 2})`,
 			Result: bass.Bindings{"a": bass.Int(1), "b": bass.Int(2)}.Scope(),
 			Log:    []string{"INFO\t{:a 1 :b 2}"},
 		},
 		{
-			Name:   "logf",
-			Bass:   `(logf "oh no! %s: %d" "bam" 42)`,
-			Result: bass.Null{},
-			Log:    []string{"INFO\toh no! bam: 42"},
+			Name:   "log non-string with fields",
+			Bass:   `(log {:a 1 :b 2} :to {:thine ["own" "self"]} :b true)`,
+			Result: bass.Bindings{"a": bass.Int(1), "b": bass.Int(2)}.Scope(),
+			Log:    []string{`INFO\t{:a 1 :b 2}\t\{\"to\": \{\"thine\": \[\"own\", \"self\"\]\}, \"b\": true\}`},
 		},
 	} {
 		t.Run(example.Name, example.Run)

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -795,11 +795,6 @@ func TestGroundConstructors(t *testing.T) {
 			),
 		},
 		{
-			Name:     "errorf",
-			Bass:     `(errorf "oh no! %s: %d" "bam" 42)`,
-			ErrEqual: fmt.Errorf("oh no! bam: 42"),
-		},
-		{
 			Name:   "now minute",
 			Bass:   `(now 60)`,
 			Result: bass.String(fakeClock.Now().Truncate(time.Minute).UTC().Format(time.RFC3339)),

--- a/pkg/bass/list.go
+++ b/pkg/bass/list.go
@@ -146,7 +146,7 @@ func EncodeList(list List, enc zapcore.ArrayEncoder) error {
 		} else if v.Decode(&om) == nil {
 			enc.AppendObject(om)
 		} else {
-			return EncodeError{v}
+			enc.AppendString(v.String())
 		}
 
 		return nil

--- a/pkg/bass/pair.go
+++ b/pkg/bass/pair.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	"go.uber.org/zap/zapcore"
 )
 
 type Pair struct {
@@ -72,6 +74,9 @@ func (value Pair) Decode(dest any) error {
 	case *Bindable:
 		*x = value
 		return nil
+	case *zapcore.ArrayMarshaler:
+		*x = value
+		return nil
 	default:
 		return decodeSlice(value, dest)
 	}
@@ -110,6 +115,12 @@ func (binding Pair) Bind(ctx context.Context, scope *Scope, cont Cont, value Val
 
 func (binding Pair) EachBinding(cb func(Symbol, Range) error) error {
 	return EachBindingList(binding, cb)
+}
+
+var _ zapcore.ArrayMarshaler = Empty{}
+
+func (pair Pair) MarshalLogArray(enc zapcore.ArrayEncoder) error {
+	return EncodeList(pair, enc)
 }
 
 func formatList(list List, odelim, cdelim string) string {

--- a/pkg/bass/scope.go
+++ b/pkg/bass/scope.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+
+	"go.uber.org/zap/zapcore"
 )
 
 // Scope contains bindings from symbols to values, and parent scopes to
@@ -50,6 +52,33 @@ func NewScope(bindings Bindings, parents ...*Scope) *Scope {
 	}
 
 	return scope
+}
+
+func Assoc(obj *Scope, kv ...Value) (*Scope, error) {
+	clone := obj.Copy()
+
+	var k Symbol
+	var v Value
+	for i := 0; i < len(kv); i++ {
+		if i%2 == 0 {
+			err := kv[i].Decode(&k)
+			if err != nil {
+				return nil, err
+			}
+		} else {
+			err := kv[i].Decode(&v)
+			if err != nil {
+				return nil, err
+			}
+
+			clone.Set(k, v)
+
+			k = ""
+			v = nil
+		}
+	}
+
+	return clone, nil
 }
 
 // Bindable is any value which may be used to destructure a value into bindings
@@ -162,6 +191,9 @@ func (value *Scope) Decode(dest any) error {
 		*x = *value
 		return nil
 	case *Value:
+		*x = value
+		return nil
+	case *zapcore.ObjectMarshaler:
 		*x = value
 		return nil
 	case Decodable:
@@ -360,6 +392,35 @@ func (scope *Scope) Complete(prefix string) []CompleteOpt {
 	}
 
 	return opts
+}
+
+var _ zapcore.ObjectMarshaler = (*Scope)(nil)
+
+func (scope *Scope) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return scope.Each(func(k Symbol, v Value) error {
+		key := k.String()
+
+		var str string
+		var num int
+		var bol bool
+		var am zapcore.ArrayMarshaler
+		var om zapcore.ObjectMarshaler
+		if v.Decode(&str) == nil {
+			enc.AddString(key, str)
+		} else if v.Decode(&num) == nil {
+			enc.AddInt(key, num)
+		} else if v.Decode(&bol) == nil {
+			enc.AddBool(key, bol)
+		} else if v.Decode(&am) == nil {
+			enc.AddArray(key, am)
+		} else if v.Decode(&om) == nil {
+			enc.AddObject(key, om)
+		} else {
+			return EncodeError{v}
+		}
+
+		return nil
+	})
 }
 
 type CompleteOpt struct {

--- a/pkg/bass/scope.go
+++ b/pkg/bass/scope.go
@@ -416,7 +416,7 @@ func (scope *Scope) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 		} else if v.Decode(&om) == nil {
 			enc.AddObject(key, om)
 		} else {
-			return EncodeError{v}
+			enc.AddString(key, v.String())
 		}
 
 		return nil

--- a/std/root.bass
+++ b/std/root.bass
@@ -421,7 +421,7 @@
 (provide (case)
   (defn case-branches [scope val branches]
     (if (empty? branches)
-      (errorf "no matching case branch for %s" val)
+      (error "no matching case branch" :target val)
       (let [[pattern expr & rest] branches
             child (make-scope scope)]
         (if (bind child pattern val)

--- a/std/run.bass
+++ b/std/run.bass
@@ -116,7 +116,7 @@
                          (conj names (path-name tag-or-path)))
 
           true
-          (errorf "invalid image path segment: %s" tag-or-path)))))
+          (error "invalid image path segment" :segment tag-or-path)))))
 
   ; returns a path root for resolving images with the given platform
   ;

--- a/std/streams.bass
+++ b/std/streams.bass
@@ -38,7 +38,7 @@
 ;
 ; => (def odds (list->source [1 3 5]))
 ;
-; => (for [a evens b odds] (logf "nums: %d %d" a b))
+; => (for [a evens b odds] (log "got" :a a :b b))
 ^:indent
 (defop for [bindings & body] scope
   (let [sources (map-pairs (fn [_ src] src) bindings)


### PR DESCRIPTION
* `(logf)` and `(errorf)` were chucked in hastily without any plan really
* formatting strings beget language spec / implementation complexity (currently tightly coupled to Go's `fmt`)
* `(log)` and `(error)` now accept kwargs for arbitrary fields
* structured logs are easier to write and easier to parse
* structured errors are equally helpful