### PR TITLE
run `git fetch origin REF` before `git checkout`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,9 @@ This will run each check defined in [project.bass](project.bass) and reflect
 its status on the current `HEAD` commit in whatever repository you specify -
 i.e. your fork.
 
-This is currently an honor system, but in the future I'd like to be able to
-publish the thunks that ran somewhere so the upstream maintainer can verify it
-by viewing the output, inspecting the thunk, and/or running it themselves.
-
+I'll still have to run the checks again myself since your own repo's check
+results won't propagate to the PR, but running them yourself will at least let
+you know they'll pass when I do.
 
 ### Source code primer
 

--- a/bass/checks
+++ b/bass/checks
@@ -18,9 +18,9 @@
 ; and waits for them all to complete.
 (defn main []
   (for [{(:repo "vito/bass") repo
+         (:clone-url "https://github.com/vito/bass") clone-url
          :sha sha} *stdin*]
-    (let [clone-url (str "https://github.com/" repo)
-          src (git:checkout clone-url sha)
+    (let [src (git:checkout clone-url sha)
           project (load (*dir*/../project))]
       (map (fn [wait] (log "check completed" :result (wait)))
            (project:start-checks src sha repo status-client)))))

--- a/std/git.bass
+++ b/std/git.bass
@@ -19,6 +19,26 @@
         next
         first))
 
+  (defn clone [repo]
+    (from *git-image*
+      ($ git clone $repo ./)))
+
+  (defn checkout-init [thunk ref]
+    (from thunk
+      ; we may be given a commit from an obscure ref, so we'll need to make
+      ; sure it's fetched first
+      ($ git fetch origin $ref)
+
+      ; checkout the commit (note: this puts us on a detached HEAD)
+      ($ git checkout $ref)
+
+      ; opinion: submodules being initialized is a baseline assumption when
+      ; working with any git repository. it's incredibly annoying to have
+      ; things trip on this by default. yes, it may take time if your repo
+      ; has a hundred submodules and you only need a handful. if you need
+      ; something more shophisticated, don't use this.
+      ($ git submodule update --init --recursive)))
+
   ; returns the repo checked out to the given ref
   ;
   ; The thunk for cloning the repo is labeled with the given ref. If the ref
@@ -31,12 +51,9 @@
   ;
   ; => (git:checkout "https://github.com/vito/bass" "ea8cae6d4c871cb14448d7254843d86dbab8505f")
   (defn checkout [repo ref]
-    (subpath
-      (from *git-image*
-        (-> ($ git clone $repo ./) (with-label :for ref))
-        ($ git checkout $ref)
-        ($ git submodule update --init --recursive))
-      ./))
+    (-> (clone repo)
+        (checkout-init ref)
+        (subpath ./)))
 
   (defn memo-ls-remote [memos]
     (memo memos (.git *git-image*) :ls-remote))


### PR DESCRIPTION
In order to run checks against someone's forked PR, I'll need to be able to checkout the PR refs (`refs/pull/123/head`).

Along the way, remove the  `:for` label from `git clone` - just let it be cached, now that we have an explicit `git fetch` for the desired ref. It could make sense to allow a configurable label here in the future for e.g. weekly cache updating.

Also update the CONTRIBUTING docs.