### PR TITLE
tweaks to make runtimes more remote-friendly

### DIFF
--- a/pkg/bass/config.go
+++ b/pkg/bass/config.go
@@ -1,7 +1,9 @@
 package bass
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 
 	"github.com/adrg/xdg"
@@ -18,9 +20,48 @@ type Config struct {
 // Additional configuration may be specified; it will be read from the runtime
 // by finding the config associated to the platform on the thunk it receives.
 type RuntimeConfig struct {
-	Platform Platform `json:"platform"`
-	Runtime  string   `json:"runtime"`
-	Config   *Scope   `json:"config,omitempty"`
+	Platform Platform     `json:"platform"`
+	Runtime  string       `json:"runtime"`
+	Addrs    RuntimeAddrs `json:"addrs,omitempty"`
+	Config   *Scope       `json:"config,omitempty"`
+}
+
+// RuntimeAddrs contains addresses of various services.
+type RuntimeAddrs struct {
+	addrs map[string]*url.URL
+}
+
+func (addrs RuntimeAddrs) Service(name string) (*url.URL, bool) {
+	if addrs.addrs == nil {
+		return nil, false
+	}
+
+	u, found := addrs.addrs[name]
+	return u, found
+}
+
+func (addrs *RuntimeAddrs) UnmarshalJSON(p []byte) error {
+	newAddrs := RuntimeAddrs{
+		addrs: make(map[string]*url.URL),
+	}
+
+	var m map[string]string
+	if err := json.Unmarshal(p, &m); err != nil {
+		return fmt.Errorf("malformed addrs: %w", err)
+	}
+
+	for name, urlStr := range m {
+		u, err := url.Parse(urlStr)
+		if err != nil {
+			return fmt.Errorf("addr %q: %w", name, err)
+		}
+
+		newAddrs.addrs[name] = u
+	}
+
+	*addrs = newAddrs
+
+	return nil
 }
 
 // LoadConfig loads a Config from the JSON file at the given path.

--- a/pkg/bass/config.go
+++ b/pkg/bass/config.go
@@ -31,6 +31,14 @@ type RuntimeAddrs struct {
 	addrs map[string]*url.URL
 }
 
+func (addrs *RuntimeAddrs) SetService(name string, u *url.URL) {
+	if addrs.addrs == nil {
+		addrs.addrs = map[string]*url.URL{}
+	}
+
+	addrs.addrs[name] = u
+}
+
 func (addrs RuntimeAddrs) Service(name string) (*url.URL, bool) {
 	if addrs.addrs == nil {
 		return nil, false

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -160,6 +160,7 @@ func (runtime *Buildkit) Resolve(ctx context.Context, imageRef bass.ThunkImageRe
 	}
 
 	statusProxy := forwardStatus(progrock.RecorderFromContext(ctx))
+	defer statusProxy.Wait()
 
 	_, err = runtime.Client.Build(ctx, kitdclient.SolveOpt{
 		Session: []session.Attachable{
@@ -331,6 +332,7 @@ func (runtime *Buildkit) build(ctx context.Context, thunk bass.Thunk, captureStd
 	var allowed []entitlements.Entitlement
 
 	statusProxy := forwardStatus(progrock.RecorderFromContext(ctx))
+	defer statusProxy.Wait()
 
 	// build llb definition using the remote gateway for image resolution
 	_, err := runtime.Client.Build(ctx, kitdclient.SolveOpt{
@@ -581,6 +583,7 @@ func (b *builder) unpackImageArchive(ctx context.Context, thunkPath bass.ThunkPa
 	}
 
 	statusProxy := forwardStatus(progrock.RecorderFromContext(ctx))
+	defer statusProxy.Wait()
 
 	_, err = b.runtime.Client.Build(ctx, kitdclient.SolveOpt{
 		LocalDirs:           b.localDirs,
@@ -852,6 +855,10 @@ func (proxy *statusProxy) Writer() chan *kitdclient.SolveStatus {
 	}()
 
 	return statuses
+}
+
+func (proxy *statusProxy) Wait() {
+	proxy.wg.Wait()
 }
 
 func (proxy *statusProxy) NiceError(msg string, err error) bass.NiceError {

--- a/pkg/runtimes/pool.go
+++ b/pkg/runtimes/pool.go
@@ -28,7 +28,7 @@ func NewPool(config *bass.Config) (*Pool, error) {
 	pool.Bass = NewBass(pool)
 
 	for _, config := range config.Runtimes {
-		runtime, err := Init(config.Runtime, pool, config.Config)
+		runtime, err := Init(config, pool)
 		if err != nil {
 			return nil, fmt.Errorf("init runtime for platform %s: %w", config.Platform, err)
 		}

--- a/pkg/runtimes/registry.go
+++ b/pkg/runtimes/registry.go
@@ -5,7 +5,7 @@ import "github.com/vito/bass/pkg/bass"
 var runtimes = map[string]InitFunc{}
 
 // InitFunc is a Runtime constructor.
-type InitFunc func(bass.RuntimePool, *bass.Scope) (bass.Runtime, error)
+type InitFunc func(bass.RuntimePool, bass.RuntimeAddrs, *bass.Scope) (bass.Runtime, error)
 
 // Register installs a runtime under a given name.
 //
@@ -16,13 +16,13 @@ func RegisterRuntime(name string, init InitFunc) {
 }
 
 // Init initializes the runtime registered under the given name.
-func Init(name string, pool bass.RuntimePool, config *bass.Scope) (bass.Runtime, error) {
-	init, found := runtimes[name]
+func Init(config bass.RuntimeConfig, pool bass.RuntimePool) (bass.Runtime, error) {
+	init, found := runtimes[config.Runtime]
 	if !found {
 		return nil, UnknownRuntimeError{
-			Name: name,
+			Name: config.Runtime,
 		}
 	}
 
-	return init(pool, config)
+	return init(pool, config.Addrs, config.Config)
 }


### PR DESCRIPTION
* replace 'data dir' with just using tmpdir
  * This doesn't make as much sense anymore; ideally runtimes should be stateless if they're gonna be run by a central [bass loop](https://github.com/vito/bass-loop).
  * It'd be nice to do without the tmpdir entirely but I don't see a good way to do that in buildkit atm.
* give addresses an explicit section for configuration
  * by promoting addrs from the black-box config we can do fancy things like dynamically provide them