### PR TITLE
stop relying on /../ hack for host paths

### DIFF
--- a/bass/bass.bass
+++ b/bass/bass.bass
@@ -1,0 +1,159 @@
+; location to track dependency resolution
+(def *memos*
+  *dir*/bass.lock)
+
+; load dependencies
+(use (.git (linux/alpine/git))
+     (git:github/vito/tabs/ref/main/nix))
+
+; clones the repo and checks out the given sha
+(defn checkout [sha]
+  (git:github/vito/bass/sha/ sha))
+
+(provide [deps+go]
+  ; monolithic image containing dependencies for building and testing
+  (defn deps [src]
+    {:file (nix:result
+             (-> ($ nix build ".#depsOci")
+                 (with-mount src/nix/ ./nix/)
+                 (with-mount src/flake.nix ./flake.nix)
+                 (with-mount src/flake.lock ./flake.lock)
+                 (with-mount src/default.nix ./default.nix))
+             ./image.tar)
+     :platform {:os "linux"}
+     :tag "latest"})
+
+  ; deps with Go dependencies pre-fetched
+  (defn deps+go [src]
+    (from (deps src)
+      ($ cp src/go.mod src/go.sum ./)
+      ($ go mod download))))
+
+(provide [build smoke-test tests docs]
+  ; compiles a bass binary for the given platform and puts it in an archive
+  (defn build [src version os arch]
+    (let [staged (from (make-shims src)
+                   ($ make
+                      (str "VERSION=" version)
+                      (str "GOOS=" os)
+                      (str "GOARCH=" arch)
+                      "DESTDIR=./dist/"
+                      install))]
+      (archive src staged/dist/ os arch)))
+
+  ; returns a thunk with the make targets built into the output directory, as
+  ; an overlay of src
+  (defn make-shims [src]
+    (-> ($ make -j shims)
+        (with-mount src ./)
+        (with-image (deps+go src))))
+
+  ; creates an archive appropriate for the given platform
+  (defn archive [src out os arch]
+    (let [prefix (str "bass." os "-" arch)
+          tgz-path (string->fs-path (str prefix ".tgz"))
+          zip-path (string->fs-path (str prefix ".zip"))]
+      (if (= os "windows")
+        (zip src zip-path out ./bass)
+        (tar-czf src tgz-path out ./bass))))
+
+  (defn tar-czf [src tarname dir & files]
+    (-> ($ tar -C $dir -czf $tarname & $files)
+        (with-image (deps+go src))
+        (subpath tarname)))
+
+  (defn zip [src zipname dir & files]
+    (-> ($ zip (../ zipname) & $files)
+        (with-image (deps+go src))
+        (with-mount dir ./content/)
+        (with-dir ./content/)
+        (subpath zipname)))
+
+  ; runs a quick sanity check
+  (defn check-dist [dist image]
+    (let [unpacked (from image
+                     ($ tar -zxf $dist))]
+      (run (from unpacked
+             ($ ./bass --version)))
+      (if (succeeds? (from unpacked
+                       ($ ldd ./bass)))
+        (error "binary is not statically linked")
+        :ok)))
+
+  ; images to test the binary against
+  (def smoke-tests
+    [(linux/ubuntu)
+     (linux/alpine)])
+
+  ; runs a basic sanity check, ensuring the binary runs in a handful of
+  ; platforms
+  ;
+  ; in reality this only checks the Linux binary since there are no
+  ; Windows/Darwin runtimes yet
+  (defn smoke-test [dist]
+    (map (fn [image] (check-dist dist image))
+         smoke-tests))
+
+  (defn with-deps [src test-thunk]
+    (-> test-thunk
+        (wrap-cmd ./hack/with-deps) ; TODO: maybe swap the order here
+        (with-image (make-shims src))
+        ; runtime tests currently need elevated privileges
+        insecure!))
+
+  ; returns a directory containing the built docs HTML
+  (defn docs [src]
+    (subpath
+      (with-deps src
+        ($ ./docs/scripts/build))
+      ./docs/))
+
+  ; returns a thunk that will run the tests and return cover.html
+  (defn tests [src testflags]
+    (from (with-deps src
+            ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
+               --
+               -cover
+               -coverprofile ./cover.out
+               -covermode count
+               & $testflags))
+
+      ; report slow tests
+      ($ gotestsum tool slowest --jsonfile ./tests.log --threshold "500ms")
+
+      ; generate coverage report
+      ($ go tool cover -html ./cover.out -o ./cover.html))))
+
+; checks that the nix flake + build can run successfully
+(defn nix-checks [src]
+  (from nix:image
+    (cd src
+      (nix:with-cache ($ nix flake metadata))
+      (nix:with-cache ($ nix flake check))
+      (nix:with-cache ($ nix build)))))
+
+(provide [release-notes]
+  ; undoes line wrapping in a given file
+  ;
+  ; GitHub releases, for whatever reason, respect word wrapping in the release
+  ; body which makes it look pretty hideous on the desktop.
+  ;
+  ; Returns a memory-backed file, so this can be shimmed in-place.
+  (defn undo-wordwrap [src file]
+    (mkfile ./wide.txt
+      (-> ($ markdownfmt $file)
+          (with-image (deps+go src))
+          (read :raw)
+          next)))
+
+  ; returns the path to the release notes for the given version
+  (defn release-notes [src version]
+    (let [notes (string->fs-path (str version ".md"))]
+      (undo-wordwrap src (src/notes/ notes)))))
+
+(provide [release]
+  (use (git:github/vito/tabs/ref/main/gh))
+
+  ; returns the github release module
+  (defn release [token]
+    (gh:release "vito/bass" token)))

--- a/bass/bass.lock
+++ b/bass/bass.lock
@@ -1,19 +1,12 @@
 {
   "memo": {
-    "5uZkUMIrLUXO5jqBMgT7s77aiMN45NtxfNZerbEMslk=:ls-remote": [
+    "JaZMqYcTF5abEAZclHSzXOrHhBCf0q_E008Q5gXQyVk=:ls-remote": [
       {
         "input": [
           "https://github.com/vito/tabs",
           "main"
         ],
-        "output": "bb63d4bc6944222c58d252e4a30df5c07ce00180"
-      },
-      {
-        "input": [
-          "https://github.com/vito/bass-loop",
-          "main"
-        ],
-        "output": "46ebe3455e4789d0461b62031fa3a18808b6ee04"
+        "output": "ca4cbd159ef130db7479af76d9f903ff132a43e1"
       }
     ],
     "LR-ZTgqORmWVgYzlV0Tt74kKbUXf6h0bIph_heb-wHQ=:resolve": [
@@ -28,7 +21,7 @@
           }
         ],
         "output": {
-          "digest": "sha256:1283cf559e7fa83951f25b292394dc7bac783e12e2c0353ddda8e3c51583d10f",
+          "digest": "sha256:5dbc7ef3c51fd64e996c3ca819d625ca21bbc4259be166fd9a46395d5f6c6a1f",
           "platform": {
             "os": "linux"
           },
@@ -47,7 +40,7 @@
           }
         ],
         "output": {
-          "digest": "sha256:9101220a875cee98b016668342c489ff0674f247f6ca20dfc91b91c0f28581ae",
+          "digest": "sha256:26c68657ccce2cb0a31b330cb0be2b5e108d467f641c62e13ab40cbec258c68d",
           "platform": {
             "os": "linux"
           },
@@ -66,7 +59,7 @@
           }
         ],
         "output": {
-          "digest": "sha256:4edbd2beb5f78b1014028f4fbb99f3237d9561100b6881aabbf5acce2c4f9454",
+          "digest": "sha256:686d8c9dfa6f3ccfc8230bc3178d23f84eeaf7e457f36f271ab1acc53015037c",
           "platform": {
             "os": "linux"
           },
@@ -77,13 +70,13 @@
     ]
   },
   "thunks": {
-    "5uZkUMIrLUXO5jqBMgT7s77aiMN45NtxfNZerbEMslk=": {
+    "JaZMqYcTF5abEAZclHSzXOrHhBCf0q_E008Q5gXQyVk=": {
       "cmd": {
         "command": "git"
       },
       "stdin": [
         {
-          "digest": "sha256:1283cf559e7fa83951f25b292394dc7bac783e12e2c0353ddda8e3c51583d10f",
+          "digest": "sha256:5dbc7ef3c51fd64e996c3ca819d625ca21bbc4259be166fd9a46395d5f6c6a1f",
           "platform": {
             "os": "linux"
           },

--- a/bass/checks
+++ b/bass/checks
@@ -1,6 +1,7 @@
 #!/usr/bin/env bass
 
 (use (.git (linux/alpine/git))
+     (*dir*/bass)
      (*dir*/github))
 
 ; a github client that uses commit statuses for checks
@@ -20,8 +21,14 @@
   (for [{(:repo "vito/bass") repo
          (:clone-url "https://github.com/vito/bass") clone-url
          :sha sha} *stdin*]
-    (let [github (status-client repo)
-          src (git:checkout clone-url sha)
-          project (load (*dir*/../project))]
+    (def github
+      (status-client repo))
+
+    (defn start-checks [waits name thunk]
+      (cons (github:start-check thunk (str name) sha) waits))
+
+    (let [src (git:checkout clone-url sha)
+          project (load (src/project))
+          checks (project:checks src)]
       (map (fn [wait] (log "check completed" :result (wait)))
-           (project:start-checks src sha github)))))
+           (reduce-kv start-checks [] checks)))))

--- a/bass/shipit
+++ b/bass/shipit
@@ -1,8 +1,8 @@
 #!/usr/bin/env bass
 
 ; load libraries
-(use (*dir*/../project)
-     (.strings))
+(use (.strings)
+     (*dir*/bass))
 
 ; builds and publishes a GitHub release
 ;

--- a/project.bass
+++ b/project.bass
@@ -1,180 +1,27 @@
 ; location to track dependency resolution
 (def *memos*
-  *dir*/project.lock)
+  *dir*/bass/bass.lock)
 
 ; load dependencies
-(use (.strings)
-     (.git (linux/alpine/git))
-     (git:github/vito/tabs/ref/main/nix)
+(use (.git (linux/alpine/git))
+     (*dir*/bass/bass)
      (git:github/vito/bass-loop/ref/main/bass/github))
 
-; clones the repo and checks out the given sha
-(defn checkout [sha]
-  (git:github/vito/bass/sha/ sha))
+; standard suite of validations for the repo
+(defn checks [src]
+  {:build-linux (ls (bass:build src "dev" "linux" "amd64"))
+   :build-darwin (ls (bass:build src "dev" "darwin" "amd64")
+                     (bass:build src "dev" "darwin" "arm64"))
+   :build-windows (ls (bass:build src "dev" "windows" "amd64"))
+   :docs (ls (bass:docs src))
+   :test (bass:tests src ["./..."])
+   :nix (bass:nix-checks src)})
 
-(provide [checks]
-  ; standard suite of validations for the repo
-  (defn checks [src]
-    {:build-linux (ls (build src "dev" "linux" "amd64"))
-     :build-darwin (ls (build src "dev" "darwin" "amd64")
-                       (build src "dev" "darwin" "arm64"))
-     :build-windows (ls (build src "dev" "windows" "amd64"))
-     :docs (ls (docs src))
-     :test (tests src ["./..."])
-     :nix (nix-checks src)})
-
-  ; just for eyeballing the files
-  (defn ls paths
-    (from (linux/alpine)
-      ($ ls -al & $paths))))
+; just for eyeballing the files
+(defn ls paths
+  (from (linux/alpine)
+    ($ ls -al & $paths)))
 
 ; called by bass-loop
 (def github-hook
   (github:check-hook checks git))
-
-; monolithic image containing dependencies for building and testing
-(defn deps [src]
-  {:file (nix:result
-           (-> ($ nix build ".#depsOci")
-               (with-mount src/nix/ ./nix/)
-               (with-mount src/flake.nix ./flake.nix)
-               (with-mount src/flake.lock ./flake.lock)
-               (with-mount src/default.nix ./default.nix))
-           ./image.tar)
-   :platform {:os "linux"}
-   :tag "latest"})
-
-; deps with Go dependencies pre-fetched
-(defn deps+go [src]
-  (from (deps src)
-    ($ cp src/go.mod src/go.sum ./)
-    ($ go mod download)))
-
-(provide [build smoke-test tests docs]
-  ; compiles a bass binary for the given platform and puts it in an archive
-  (defn build [src version os arch]
-    (let [staged (from (make-shims src)
-                   ($ make
-                      (str "VERSION=" version)
-                      (str "GOOS=" os)
-                      (str "GOARCH=" arch)
-                      "DESTDIR=./dist/"
-                      install))]
-      (archive src staged/dist/ os arch)))
-
-  ; returns a thunk with the make targets built into the output directory, as
-  ; an overlay of src
-  (defn make-shims [src]
-    (-> ($ make -j shims)
-        (with-mount src ./)
-        (with-image (deps+go src))))
-
-  ; creates an archive appropriate for the given platform
-  (defn archive [src out os arch]
-    (let [prefix (str "bass." os "-" arch)
-          tgz-path (string->fs-path (str prefix ".tgz"))
-          zip-path (string->fs-path (str prefix ".zip"))]
-      (if (= os "windows")
-        (zip src zip-path out ./bass)
-        (tar-czf src tgz-path out ./bass))))
-
-  (defn tar-czf [src tarname dir & files]
-    (-> ($ tar -C $dir -czf $tarname & $files)
-        (with-image (deps+go src))
-        (subpath tarname)))
-
-  (defn zip [src zipname dir & files]
-    (-> ($ zip (../ zipname) & $files)
-        (with-image (deps+go src))
-        (with-mount dir ./content/)
-        (with-dir ./content/)
-        (subpath zipname)))
-
-  ; runs a quick sanity check
-  (defn check-dist [dist image]
-    (let [unpacked (from image
-                     ($ tar -zxf $dist))]
-      (run (from unpacked
-             ($ ./bass --version)))
-      (if (succeeds? (from unpacked
-                       ($ ldd ./bass)))
-        (error "binary is not statically linked")
-        :ok)))
-
-  ; images to test the binary against
-  (def smoke-tests
-    [(linux/ubuntu)
-     (linux/alpine)])
-
-  ; runs a basic sanity check, ensuring the binary runs in a handful of
-  ; platforms
-  ;
-  ; in reality this only checks the Linux binary since there are no
-  ; Windows/Darwin runtimes yet
-  (defn smoke-test [dist]
-    (map (fn [image] (check-dist dist image))
-         smoke-tests))
-
-  (defn with-deps [src test-thunk]
-    (-> test-thunk
-        (wrap-cmd ./hack/with-deps) ; TODO: maybe swap the order here
-        (with-image (make-shims src))
-        ; runtime tests currently need elevated privileges
-        insecure!))
-
-  ; returns a directory containing the built docs HTML
-  (defn docs [src]
-    (subpath
-      (with-deps src
-        ($ ./docs/scripts/build))
-      ./docs/))
-
-  ; returns a thunk that will run the tests and return cover.html
-  (defn tests [src testflags]
-    (from (with-deps src
-            ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
-               --
-               -cover
-               -coverprofile ./cover.out
-               -covermode count
-               & $testflags))
-
-      ; report slow tests
-      ($ gotestsum tool slowest --jsonfile ./tests.log --threshold "500ms")
-
-      ; generate coverage report
-      ($ go tool cover -html ./cover.out -o ./cover.html))))
-
-; checks that the nix flake + build can run successfully
-(defn nix-checks [src]
-  (from nix:image
-    (cd src
-      (nix:with-cache ($ nix flake metadata))
-      (nix:with-cache ($ nix flake check))
-      (nix:with-cache ($ nix build)))))
-
-(provide [release-notes]
-  ; undoes line wrapping in a given file
-  ;
-  ; GitHub releases, for whatever reason, respect word wrapping in the release
-  ; body which makes it look pretty hideous on the desktop.
-  ;
-  ; Returns a memory-backed file, so this can be shimmed in-place.
-  (defn undo-wordwrap [src file]
-    (mkfile ./wide.txt
-      (-> ($ markdownfmt $file)
-          (with-image (deps+go src))
-          (read :raw)
-          next)))
-
-  ; returns the path to the release notes for the given version
-  (defn release-notes [src version]
-    (let [notes (string->fs-path (str version ".md"))]
-      (undo-wordwrap src (src/notes/ notes)))))
-
-(provide [release]
-  (use (git:github/vito/tabs/ref/main/gh))
-
-  ; returns the github release module
-  (defn release [token]
-    (gh:release "vito/bass" token)))


### PR DESCRIPTION
this is an antipattern as it goes against the usual mantra of host paths
which is to be strictly limited to their context dir.

it was always hokey, and this arrangement makes it unnecessary, so I'm
keen to remove it for consistency's sake.

the fewer files required in the toplevel of the repo, the better.