### PR TITLE
add Close() to runtime interface

### DIFF
--- a/pkg/bass/fake_runtime_test.go
+++ b/pkg/bass/fake_runtime_test.go
@@ -92,3 +92,7 @@ func (fake *FakeRuntime) ExportPath(ctx context.Context, w io.Writer, path bass.
 func (fake *FakeRuntime) Prune(context.Context, bass.PruneOpts) error {
 	return fmt.Errorf("Prune unimplemented")
 }
+
+func (fake *FakeRuntime) Close() error {
+	return nil
+}

--- a/pkg/bass/runtime.go
+++ b/pkg/bass/runtime.go
@@ -19,6 +19,7 @@ type Runtime interface {
 	Export(context.Context, io.Writer, Thunk) error
 	ExportPath(context.Context, io.Writer, ThunkPath) error
 	Prune(context.Context, PruneOpts) error
+	Close() error
 }
 
 // PruneOpts contains parameters to fine-tune the pruning behavior. These

--- a/pkg/runtimes/bass.go
+++ b/pkg/runtimes/bass.go
@@ -93,6 +93,10 @@ func (runtime *Bass) ExportPath(ctx context.Context, w io.Writer, path bass.Thun
 	return fmt.Errorf("export %s: cannot export path from bass thunk", path)
 }
 
+func (runtime *Bass) Close() error {
+	return nil
+}
+
 func (runtime *Bass) run(ctx context.Context, thunk bass.Thunk, runMain bool) (*bass.Scope, []byte, error) {
 	var ext string
 	if runMain {

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -325,6 +325,10 @@ func (runtime *Buildkit) Prune(ctx context.Context, opts bass.PruneOpts) error {
 	return tw.Flush()
 }
 
+func (runtime *Buildkit) Close() error {
+	return runtime.Client.Close()
+}
+
 func (runtime *Buildkit) build(ctx context.Context, thunk bass.Thunk, captureStdout bool, transform func(llb.ExecState, string) marshalable, exports ...kitdclient.ExportEntry) error {
 	var def *llb.Definition
 	var secrets map[string][]byte

--- a/pkg/runtimes/pool.go
+++ b/pkg/runtimes/pool.go
@@ -3,6 +3,7 @@ package runtimes
 import (
 	"fmt"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/vito/bass/pkg/bass"
 )
 
@@ -65,4 +66,14 @@ func (pool *Pool) All() ([]bass.Runtime, error) {
 	}
 
 	return all, nil
+}
+
+// Close closes each runtime.
+func (pool *Pool) Close() error {
+	var errs error
+	for _, assoc := range pool.Runtimes {
+		errs = multierror.Append(errs, assoc.Runtime.Close())
+	}
+
+	return errs
 }


### PR DESCRIPTION
some runtimes maintain long-lived clients that need to be cleaned up if the runtime is only used temporarily

(needed by bass-loop)