### PR TITLE
add `(path-stem)`, restore `(path-name)` semantics

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -3,6 +3,7 @@ package bass
 import (
 	"context"
 	"errors"
+	"path"
 	"strings"
 	"time"
 
@@ -620,6 +621,24 @@ func init() {
 		`=> (path-name ./some/file)`,
 		`=> (path-name ./some/dir/)`,
 		`=> (path-name (.tests))`,
+	)
+
+	Ground.Set("path-stem",
+		Func("path-stem", "[path]", func(p Path) string {
+			name := p.Name()
+
+			ext := path.Ext(name)
+			if ext != "" {
+				name = name[:len(name)-len(ext)]
+			}
+
+			return name
+		}),
+		`returns the base name of the path, without any extension`,
+		`=> (path-stem .bash)`,
+		`=> (path-stem ./some/file.bass)`,
+		`=> (path-stem ./some/dir/)`,
+		`=> (path-stem (.tests))`,
 	)
 
 	// thunk constructors

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -1741,6 +1741,11 @@ func TestGroundPaths(t *testing.T) {
 			Result: bass.String("bar"),
 		},
 		{
+			Name:   "path-name filepath",
+			Bass:   `(path-name ./foo/bar.txt)`,
+			Result: bass.String("bar.txt"),
+		},
+		{
 			Name:   "path-name dirpath",
 			Bass:   `(path-name ./foo/bar/)`,
 			Result: bass.String("bar"),
@@ -1763,6 +1768,36 @@ func TestGroundPaths(t *testing.T) {
 		{
 			Name:   "path-name command",
 			Bass:   `(path-name .foo)`,
+			Result: bass.String("foo"),
+		},
+		{
+			Name:   "path-stem filepath",
+			Bass:   `(path-stem ./foo/bar.baz)`,
+			Result: bass.String("bar"),
+		},
+		{
+			Name:   "path-stem dirpath",
+			Bass:   `(path-stem ./foo/bar.baz/)`,
+			Result: bass.String("bar"),
+		},
+		{
+			Name:   "path-stem dirpath",
+			Bass:   `(path-stem ./foo/bar.baz/)`,
+			Result: bass.String("bar"),
+		},
+		{
+			Name:   "path-stem thunk filepath",
+			Bass:   `(path-stem (subpath (.foo) ./bar/baz.buzz))`,
+			Result: bass.String("baz"),
+		},
+		{
+			Name:   "path-stem thunk dirpath",
+			Bass:   `(path-stem (subpath (.foo) ./bar/baz.buzz/))`,
+			Result: bass.String("baz"),
+		},
+		{
+			Name:   "path-stem command",
+			Bass:   `(path-stem .foo)`,
 			Result: bass.String("foo"),
 		},
 	} {

--- a/pkg/bass/host_path_test.go
+++ b/pkg/bass/host_path_test.go
@@ -57,7 +57,7 @@ func TestHostPathName(t *testing.T) {
 	)
 
 	is.Equal(
-		"baz",
+		"baz.buzz",
 		bass.HostPath{
 			ContextDir: "/some/dir",
 			Path:       bass.ParseFileOrDirPath("./foo/bar/baz.buzz"),

--- a/pkg/bass/path.go
+++ b/pkg/bass/path.go
@@ -253,13 +253,7 @@ func (combiner FilePath) Call(ctx context.Context, val Value, scope *Scope, cont
 var _ Path = FilePath{}
 
 func (value FilePath) Name() string {
-	base := path.Base(value.Path)
-	ext := path.Ext(base)
-	if ext != "" {
-		base = base[:len(base)-len(ext)]
-	}
-
-	return base
+	return path.Base(value.Path)
 }
 
 func (path_ FilePath) Extend(ext Path) (Path, error) {

--- a/pkg/bass/path_test.go
+++ b/pkg/bass/path_test.go
@@ -58,22 +58,10 @@ func TestDirPathIsDir(t *testing.T) {
 func TestDirPathFromSlash(t *testing.T) {
 	is := is.New(t)
 
-	is.Equal(
-
-		filepath.FromSlash("./hello/foo/bar/"), bass.DirPath{"hello/foo/bar"}.FromSlash())
-
-	is.Equal(
-
-		filepath.FromSlash("/hello/foo/bar/"), bass.DirPath{"/hello/foo/bar"}.FromSlash())
-
-	is.Equal(
-
-		filepath.FromSlash("./"), bass.DirPath{"."}.FromSlash())
-
-	is.Equal(
-
-		filepath.FromSlash("./hello/foo/bar/"), bass.DirPath{"./hello/foo/bar"}.FromSlash())
-
+	is.Equal(filepath.FromSlash("./hello/foo/bar/"), bass.DirPath{"hello/foo/bar"}.FromSlash())
+	is.Equal(filepath.FromSlash("/hello/foo/bar/"), bass.DirPath{"/hello/foo/bar"}.FromSlash())
+	is.Equal(filepath.FromSlash("./"), bass.DirPath{"."}.FromSlash())
+	is.Equal(filepath.FromSlash("./hello/foo/bar/"), bass.DirPath{"./hello/foo/bar"}.FromSlash())
 }
 
 func TestDirPathName(t *testing.T) {
@@ -137,18 +125,9 @@ func TestFilePathDecode(t *testing.T) {
 func TestFilePathFromSlash(t *testing.T) {
 	is := is.New(t)
 
-	is.Equal(
-
-		filepath.FromSlash("./hello/foo/bar"), bass.FilePath{"hello/foo/bar"}.FromSlash())
-
-	is.Equal(
-
-		filepath.FromSlash("./hello/foo/bar"), bass.FilePath{"./hello/foo/bar"}.FromSlash())
-
-	is.Equal(
-
-		filepath.FromSlash("/hello/foo/bar"), bass.FilePath{"/hello/foo/bar"}.FromSlash())
-
+	is.Equal(filepath.FromSlash("./hello/foo/bar"), bass.FilePath{"hello/foo/bar"}.FromSlash())
+	is.Equal(filepath.FromSlash("./hello/foo/bar"), bass.FilePath{"./hello/foo/bar"}.FromSlash())
+	is.Equal(filepath.FromSlash("/hello/foo/bar"), bass.FilePath{"/hello/foo/bar"}.FromSlash())
 }
 
 func TestFilePathEqual(t *testing.T) {
@@ -173,7 +152,7 @@ func TestFilePathName(t *testing.T) {
 	is := is.New(t)
 
 	is.Equal("hello", bass.FilePath{"foo/hello"}.Name())
-	is.Equal("baz", bass.FilePath{"foo/bar/baz.buzz"}.Name())
+	is.Equal("baz.buzz", bass.FilePath{"foo/bar/baz.buzz"}.Name())
 }
 
 func TestFilePathExtend(t *testing.T) {

--- a/std/root.bass
+++ b/std/root.bass
@@ -276,7 +276,7 @@
       [] []
       [thunk-form & rest-forms]
       (let [thunk (eval thunk-form scope)
-            modname (string->symbol (path-name (thunk-cmd thunk)))]
+            modname (string->symbol (path-stem (thunk-cmd thunk)))]
         (cons (eval [def modname [load thunk]] scope)
               (bind-modules rest-forms scope)))))
 


### PR DESCRIPTION
previously (in v0.6.0) I changed `(path-name)` to omit file extensions so that `(use)` wouldn't end up with modules named `foo.bass`, but this was in hindsight obviously the wrong place to implement this.

this adds `(path-stem)` instead which is now used by `(use)`.