### PR TITLE
(start) calls handler with error combiner instead

### DIFF
--- a/bass/github.bass
+++ b/bass/github.bass
@@ -8,12 +8,12 @@
     (create-status sha repo auth {:context name
                                   :state "pending"})
     (start thunk
-      (fn [ok?]
+      (fn [err]
         (create-status
           sha repo auth
           {:context name
-           :state (if ok? "success" "failure")})
-        [name ok?])))
+           :state (if (null? err) "success" "failure")})
+        [name err])))
 
   ; build the gh-curl helper executable
   (def gh-curl

--- a/pkg/bass/error.go
+++ b/pkg/bass/error.go
@@ -1,0 +1,54 @@
+package bass
+
+import "context"
+
+type Error struct {
+	Err error
+}
+
+var _ Value = Error{}
+
+// Eval calls the continuation with the error.
+func (value Error) Equal(o Value) bool {
+	var other Error
+	return o.Decode(&other) == nil && value.Err == other.Err
+}
+
+// Eval calls the continuation with the error.
+func (value Error) Eval(_ context.Context, _ *Scope, cont Cont) ReadyCont {
+	return cont.Call(value, nil)
+}
+
+// String returns the error message.
+func (value Error) String() string {
+	return "<error: " + value.Err.Error() + ">"
+}
+
+// String returns the error message.
+func (value Error) Decode(dest any) error {
+	switch x := dest.(type) {
+	case *error:
+		*x = value.Err
+		return nil
+	case *Error:
+		*x = value
+		return nil
+	case *Value:
+		*x = value
+		return nil
+	case *Combiner:
+		*x = value
+		return nil
+	default:
+		return DecodeError{
+			Source:      value,
+			Destination: dest,
+		}
+	}
+}
+
+var _ Combiner = Error{}
+
+func (value Error) Call(ctx context.Context, val Value, scope *Scope, cont Cont) ReadyCont {
+	return cont.Call(nil, value.Err)
+}

--- a/pkg/bass/error_test.go
+++ b/pkg/bass/error_test.go
@@ -1,0 +1,55 @@
+package bass_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/vito/bass/pkg/bass"
+	"github.com/vito/bass/pkg/basstest"
+	"github.com/vito/is"
+)
+
+func TestErrorEqual(t *testing.T) {
+	is := is.New(t)
+	inner := errors.New("uh oh")
+	err1 := bass.Error{Err: inner}
+	err2 := bass.Error{Err: inner}
+	is.True(err1.Equal(err2))
+
+	other := errors.New("uh oh")
+	err3 := bass.Error{Err: other}
+	is.True(!err1.Equal(err3))
+}
+
+func TestErrorEval(t *testing.T) {
+	is := is.New(t)
+	errv := bass.Error{Err: errors.New("uh oh")}
+	res, err := basstest.Eval(bass.NewEmptyScope(), errv)
+	is.NoErr(err)
+	is.Equal(errv, res)
+}
+
+func TestErrorCall(t *testing.T) {
+	is := is.New(t)
+	errv := bass.Error{Err: errors.New("uh oh")}
+	res, err := basstest.Call(errv, bass.NewEmptyScope(), bass.Empty{})
+	is.Equal(errv.Err, err)
+	is.Equal(nil, res)
+}
+
+func TestErrorDecode(t *testing.T) {
+	is := is.New(t)
+	errv := bass.Error{Err: errors.New("uh oh")}
+
+	var self bass.Value
+	is.NoErr(errv.Decode(&self))
+	is.Equal(errv, self)
+
+	var other bass.Error
+	is.NoErr(errv.Decode(&other))
+	is.Equal(errv, other)
+
+	var inner error
+	is.NoErr(errv.Decode(&inner))
+	is.Equal(errv.Err, inner)
+}

--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -736,11 +736,14 @@ func init() {
 			return thunk.Start(ctx, handler)
 		}),
 		`starts running a thunk asynchronously`,
-		`The callback is called with a boolean indicating whether the thunk succeeded (true) or failed (false).`,
-		`Returns a function which can be called to wait for the result of the callback.`,
-		`=> (start (from (linux/alpine) ($ banana)) id)`,
-		`=> ((start (from (linux/alpine) ($ banana)) id))`,
-		`=> ((start (from (linux/alpine) ($ echo)) id))`)
+		`If the thunk errors or exits nonzero the handler is called with a combiner that raises the error when called.`,
+		`If the thunk runs succeeds the handler is called with null.`,
+		`=> (start (from (linux/alpine) ($ banana)) null?)`,
+		`=> ((start (from (linux/alpine) ($ banana)) null?))`,
+		`=> ((start (from (linux/alpine) ($ echo)) null?))`,
+		`=> (defn raiser [err] (and err (err)))`,
+		`=> ((start (from (linux/alpine) ($ banana)) raiser))`,
+		`=> ((start (from (linux/alpine) ($ echo)) raiser))`)
 
 	Ground.Set("read",
 		Func("read", "[thunk-or-file protocol]", func(ctx context.Context, read Readable, proto Symbol) (*Source, error) {

--- a/pkg/bass/runs_test.go
+++ b/pkg/bass/runs_test.go
@@ -25,9 +25,10 @@ func TestRuns(t *testing.T) {
 	thunk1 := bass.MustThunk(errorScpt).AppendArgs(bass.String("oh no"))
 	thunk2 := bass.MustThunk(errorScpt).AppendArgs(bass.String("let's go"))
 
-	errCb := bass.Func("err-if-not-ok", "[ok?]", func(ok bool) error {
-		if !ok {
-			return fmt.Errorf("it failed!")
+	errCb := bass.Func("err-if-not-ok", "[err]", func(merr bass.Value) error {
+		var errv bass.Error
+		if err := merr.Decode(&errv); err == nil {
+			return fmt.Errorf("it failed!: %w", errv.Err)
 		}
 
 		return nil

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -223,14 +223,16 @@ func (thunk Thunk) Start(ctx context.Context, handler Combiner) (Combiner, error
 
 		runErr := thunk.Run(ctx)
 
-		ok := runErr == nil
-
-		res, err := Trampoline(ctx, handler.Call(ctx, NewList(Bool(ok)), NewEmptyScope(), Identity))
-		if err != nil {
-			waitErr = fmt.Errorf("%s: %w", err, runErr)
+		var errv Value
+		if runErr != nil {
+			errv = Error{runErr}
 		} else {
-			waitRes = res
+			errv = Null{}
 		}
+
+		cont := handler.Call(ctx, NewList(errv), NewEmptyScope(), Identity)
+
+		waitRes, waitErr = Trampoline(ctx, cont)
 
 		return waitErr
 	})

--- a/pkg/runtimes/testdata/error.bass
+++ b/pkg/runtimes/testdata/error.bass
@@ -1,0 +1,2 @@
+(run (from (linux/alpine) ($ sh -c "exit 0")))
+(run (from (linux/alpine) ($ sh -c "exit 42")))

--- a/std/root.bass
+++ b/std/root.bass
@@ -523,7 +523,7 @@
 ;
 ; => (succeeds? (from (linux/alpine) (.true)))
 (defn succeeds? [thunk]
-  ((start thunk id)))
+  ((start thunk null?)))
 
 ; runs a thunk
 ;
@@ -533,5 +533,4 @@
 ;
 ; => (run (from (linux/alpine) ($ echo "Hello, world!")))
 (defn run [thunk]
-  ((start thunk
-          (fn [ok?] (if ok? null (error (str thunk)))))))
+  ((start thunk (fn [err] (and err (err))))))


### PR DESCRIPTION
previously `(start)` would call the handler with a bool indicating success. if the handler raised an error, it would actually be used to wrap the root error. this was always a little surprising.

meanwhile the handler had no way to access the root cause of the error, e.g. to log it using cli.WriteError(ctx, err), which I need to do in Bass Loop.

now the handler is called with a nullable combiner. if null, the thunk succeeded. if a combiner is present, it can be called to propagate the error to whoever waits on the thunk run.

to accomplish this a special Error combiner value has been introduced. it displays like <error: inner error msg> and when called returns the inner error.

the new implementation of `(succeeds?)` and `(run)` feel a bit cleaner: https://github.com/vito/bass/compare/anustart?expand=1#diff-23e0b46edf759eda1782b1de1613ddb63c137769ab51736200319a85ccde9d6c

side note: this is continuing along an "everything is a combiner" trend, which feels pretty intuitive for errors imo: errors are often wrapped, i.e. combined. so this combiner could be tweaked to take a wrapping message or something if we want. maybe a string and fields to avoid formatting and maintain symmetry with `(error)`?