### PR TITLE
leverage caching for rendering traces

### DIFF
--- a/pkg/cli/error.go
+++ b/pkg/cli/error.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"strings"
 
 	"github.com/alecthomas/chroma/formatters"
@@ -92,7 +93,14 @@ func Annotate(ctx context.Context, out io.Writer, loc bass.Range) {
 
 	fmt.Fprintf(out, aec.YellowF.Apply("%s ┆ %s")+"\n", pad, loc)
 
-	f, err := loc.File.Open(ctx)
+	srcFile, err := loc.File.CachePath(ctx, bass.CacheHome)
+	if err != nil {
+		fmt.Fprintf(out, aec.RedF.Apply("%s ! could not open frame source: %s")+"\n", pad, err)
+		fmt.Fprintln(out)
+		return
+	}
+
+	f, err := os.Open(srcFile)
 	if err != nil {
 		fmt.Fprintf(out, aec.RedF.Apply("%s ! could not open frame source: %s")+"\n", pad, err)
 		fmt.Fprintln(out)


### PR DESCRIPTION
previously it was possible to load a cached file and run it without a runtime but then fail to render its content in the trace printed to stderr:

    error! call trace (oldest first):

       ┆ <fs>/project.bass:35:2..35:45
    35 │   (github:check-hook event client git checks))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

       ┆ <thunk: (.git) name:yPieviqhlsa6uTBhT-gpoQDbzpMyl1owqphA_l6wt0Y=>/bass/github.bass:3:4..54:66
       ! could not open frame source: no runtime configured for os=linux, arch=any

       ┆ (6 internal calls elided)
       ┆ <thunk: (.git) name:yPieviqhlsa6uTBhT-gpoQDbzpMyl1owqphA_l6wt0Y=>/bass/github.bass:5:6..17:68
       ! could not open frame source: no runtime configured for os=linux, arch=any

       ┆ (6 internal calls elided)
       ┆ <thunk: (.git) name:yPieviqhlsa6uTBhT-gpoQDbzpMyl1owqphA_l6wt0Y=>/bass/github.bass:9:8..9:71
       ! could not open frame source: no runtime configured for os=linux, arch=any

       ┆ <thunk: (.git) name:yPieviqhlsa6uTBhT-gpoQDbzpMyl1owqphA_l6wt0Y=>/bass/github.bass:57:4..59:27
       ! could not open frame source: no runtime configured for os=linux, arch=any

    no runtime configured for os=linux, arch=any

live example [here](https://loop.bass-lang.org/runs/a126ec81-8d4a-4af1-afe7-d377232160ab)

now if it's able to get that far it'll use the cached file for rendering the actual code too.