### PR TITLE
switch from sha256 to xxh3

### DIFF
--- a/demos/cat.bass
+++ b/demos/cat.bass
@@ -1,0 +1,5 @@
+(use (.git (linux/alpine/git)))
+
+(-> ($ cat git:github/vito/bass/ref/main/README.md)
+    (with-image (linux/alpine))
+    run)

--- a/demos/git-lib-backtrace.bass
+++ b/demos/git-lib-backtrace.bass
@@ -1,0 +1,4 @@
+(use (.git (linux/alpine/git))
+     (git:github/vito/bass/ref/main/demos/backtrace.bass))
+
+(backtrace:main)

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -949,7 +949,7 @@ func (plugin *Plugin) renderThunk(thunk bass.Thunk, pathOptional ...bass.Value) 
 		return nil, err
 	}
 
-	id, err := thunk.SHA256()
+	id, err := thunk.Hash()
 	if err != nil {
 		return nil, err
 	}

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -949,7 +949,7 @@ func (plugin *Plugin) renderThunk(thunk bass.Thunk, pathOptional ...bass.Value) 
 		return nil, err
 	}
 
-	id, err := thunk.Hash()
+	hash, err := thunk.Hash()
 	if err != nil {
 		return nil, err
 	}
@@ -968,7 +968,7 @@ func (plugin *Plugin) renderThunk(thunk bass.Thunk, pathOptional ...bass.Value) 
 		Style:   "bass-thunk",
 		Content: booklit.String(avatarSvg.String()),
 		Partials: booklit.Partials{
-			"ID":    booklit.String(fmt.Sprintf("%s-%d", id, plugin.toggleID)),
+			"ID":    booklit.String(fmt.Sprintf("%s-%d", hash, plugin.toggleID)),
 			"Run":   run,
 			"Path":  path,
 			"Scope": scope,

--- a/pkg/bass/cache_path.go
+++ b/pkg/bass/cache_path.go
@@ -42,10 +42,11 @@ func (value CachePath) String() string {
 	return fmt.Sprintf("<cache: %s>/%s", value.ID, strings.TrimPrefix(value.Path.Slash(), "./"))
 }
 
+// Hash returns a non-cryptographic hash of the cache path's ID.
 func (value CachePath) Hash() string {
-	var tmp [8]byte
-	binary.BigEndian.PutUint64(tmp[:], xxh3.HashString(value.ID))
-	return base64.URLEncoding.EncodeToString(tmp[:])
+	var sum [8]byte
+	binary.BigEndian.PutUint64(sum[:], xxh3.HashString(value.ID))
+	return base64.URLEncoding.EncodeToString(sum[:])
 }
 
 func (value CachePath) Equal(other Value) bool {

--- a/pkg/bass/cache_path.go
+++ b/pkg/bass/cache_path.go
@@ -122,6 +122,7 @@ func (combiner CachePath) Call(ctx context.Context, val Value, scope *Scope, con
 var _ Path = CachePath{}
 
 func (path CachePath) Name() string {
+	// TODO: should this special-case ./ to return the thunk name?
 	return path.Path.FilesystemPath().Name()
 }
 

--- a/pkg/bass/host_path.go
+++ b/pkg/bass/host_path.go
@@ -2,6 +2,8 @@ package bass
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -9,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/vito/bass/pkg/proto"
+	"github.com/zeebo/xxh3"
 )
 
 // HostPath is a Path representing an absolute path on the host machine's
@@ -44,6 +47,13 @@ func ParseHostPath(path string) HostPath {
 
 func (value HostPath) String() string {
 	return fmt.Sprintf("<host: %s>", value.fpath())
+}
+
+// Hash returns a non-cryptographic hash of the host path's context dir.
+func (value HostPath) Hash() string {
+	var sum [8]byte
+	binary.BigEndian.PutUint64(sum[:], xxh3.HashString(value.ContextDir))
+	return base64.URLEncoding.EncodeToString(sum[:])
 }
 
 func (value HostPath) Equal(other Value) bool {

--- a/pkg/bass/session.go
+++ b/pkg/bass/session.go
@@ -43,7 +43,7 @@ func (runtime *Session) Read(ctx context.Context, w io.Writer, thunk Thunk) erro
 }
 
 func (runtime *Session) Load(ctx context.Context, thunk Thunk) (*Scope, error) {
-	key, err := thunk.SHA256()
+	key, err := thunk.Hash()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -392,13 +392,13 @@ var _ Path = Thunk{}
 // Name returns the unqualified name for the path, i.e. the base name of a
 // file or directory, or the name of a command.
 func (thunk Thunk) Name() string {
-	digest, err := thunk.Hash()
+	hash, err := thunk.Hash()
 	if err != nil {
 		// this is awkward, but it's better than panicking
 		return fmt.Sprintf("(error: %s)", err)
 	}
 
-	return digest
+	return hash
 }
 
 // Extend returns a path referring to the given path relative to the parent
@@ -489,8 +489,8 @@ func (thunk *Thunk) Platform() *Platform {
 }
 
 // Hash returns a stable, non-cryptographic hash derived from the thunk.
-func (wl Thunk) Hash() (string, error) {
-	msg, err := wl.MarshalProto()
+func (thunk Thunk) Hash() (string, error) {
+	msg, err := thunk.MarshalProto()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -2,8 +2,8 @@ package bass
 
 import (
 	"context"
-	"crypto/sha256"
 	"encoding/base64"
+	"encoding/binary"
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
@@ -16,6 +16,7 @@ import (
 
 	"github.com/vito/bass/pkg/proto"
 	"github.com/vito/invaders"
+	"github.com/zeebo/xxh3"
 	"google.golang.org/protobuf/encoding/protojson"
 	gproto "google.golang.org/protobuf/proto"
 )
@@ -360,7 +361,7 @@ func (thunk Thunk) WithLabel(key Symbol, val Value) Thunk {
 var _ Value = Thunk{}
 
 func (thunk Thunk) String() string {
-	return fmt.Sprintf("<thunk: %s name:%s>", NewList(thunk.Cmd.ToValue()), thunk.Name())
+	return fmt.Sprintf("<thunk %s: %s>", thunk.Name(), NewList(thunk.Cmd.ToValue()))
 }
 
 func (thunk Thunk) Equal(other Value) bool {
@@ -391,7 +392,7 @@ var _ Path = Thunk{}
 // Name returns the unqualified name for the path, i.e. the base name of a
 // file or directory, or the name of a command.
 func (thunk Thunk) Name() string {
-	digest, err := thunk.SHA256()
+	digest, err := thunk.Hash()
 	if err != nil {
 		// this is awkward, but it's better than panicking
 		return fmt.Sprintf("(error: %s)", err)
@@ -487,8 +488,8 @@ func (thunk *Thunk) Platform() *Platform {
 	return thunk.Image.Platform()
 }
 
-// SHA256 returns a stable SHA256 hash derived from the thunk.
-func (wl Thunk) SHA256() (string, error) {
+// Hash returns a stable, non-cryptographic hash derived from the thunk.
+func (wl Thunk) Hash() (string, error) {
 	msg, err := wl.MarshalProto()
 	if err != nil {
 		return "", err
@@ -499,7 +500,8 @@ func (wl Thunk) SHA256() (string, error) {
 		return "", err
 	}
 
-	sum := sha256.Sum256(payload)
+	var sum [8]byte
+	binary.BigEndian.PutUint64(sum[:], xxh3.Hash(payload))
 	return base64.URLEncoding.EncodeToString(sum[:]), nil
 }
 
@@ -524,7 +526,7 @@ func (wl Thunk) Avatar() (*invaders.Invader, error) {
 var _ Readable = Thunk{}
 
 func (thunk Thunk) CachePath(ctx context.Context, dest string) (string, error) {
-	digest, err := thunk.SHA256()
+	digest, err := thunk.Hash()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/bass/thunk_path.go
+++ b/pkg/bass/thunk_path.go
@@ -145,6 +145,7 @@ func (combiner ThunkPath) Call(ctx context.Context, val Value, scope *Scope, con
 var _ Path = ThunkPath{}
 
 func (path ThunkPath) Name() string {
+	// TODO: should this special-case ./ to return the thunk name?
 	return path.Path.FilesystemPath().Name()
 }
 

--- a/pkg/bass/thunk_path.go
+++ b/pkg/bass/thunk_path.go
@@ -3,15 +3,17 @@ package bass
 import (
 	"archive/tar"
 	"context"
-	"crypto/sha256"
-	"encoding/json"
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"path/filepath"
 	"strings"
 
 	"github.com/vito/bass/pkg/proto"
+	"github.com/zeebo/xxh3"
 	"google.golang.org/protobuf/encoding/protojson"
+	gproto "google.golang.org/protobuf/proto"
 )
 
 // A path created by a thunk.
@@ -22,14 +24,21 @@ type ThunkPath struct {
 
 var _ Value = ThunkPath{}
 
-// SHA256 returns a stable SHA256 hash derived from the thunk path.
-func (wl ThunkPath) SHA256() (string, error) {
-	payload, err := json.Marshal(wl)
+// Hash returns a non-cryptographic hash derived from the thunk path.
+func (thunkPath ThunkPath) Hash() (string, error) {
+	msg, err := thunkPath.MarshalProto()
 	if err != nil {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", sha256.Sum256(payload)), nil
+	payload, err := gproto.Marshal(msg)
+	if err != nil {
+		return "", err
+	}
+
+	var sum [8]byte
+	binary.BigEndian.PutUint64(sum[:], xxh3.Hash(payload))
+	return base64.URLEncoding.EncodeToString(sum[:]), nil
 }
 
 func (value ThunkPath) String() string {
@@ -160,7 +169,7 @@ func (path ThunkPath) Dir() ThunkPath {
 var _ Readable = ThunkPath{}
 
 func (path ThunkPath) CachePath(ctx context.Context, dest string) (string, error) {
-	digest, err := path.SHA256()
+	digest, err := path.Hash()
 	if err != nil {
 		return "", err
 	}

--- a/pkg/bass/thunk_test.go
+++ b/pkg/bass/thunk_test.go
@@ -28,10 +28,10 @@ func TestThunkSHA256(t *testing.T) {
 		},
 	}
 
-	sha2, err := thunk.SHA256()
+	hash, err := thunk.Hash()
 	is.NoErr(err)
 
 	// this is a bit silly, but it's deterministic, and we need to make sure it's
 	// always the same value
-	is.Equal(sha2, "hNkfayFxHacmtv9iHIeF_oXqErdfEegagwrvQYwiOko=")
+	is.Equal(hash, "zYYfyxif8Zo=")
 }

--- a/pkg/bass/value_test.go
+++ b/pkg/bass/value_test.go
@@ -470,7 +470,7 @@ func TestString(t *testing.T) {
 					Dir: &bass.DirPath{"dir"},
 				},
 			},
-			"<thunk: (./file) name:HHZBgoRTcgyJbvyAn36WxovnEmyCFelnup4YOwNSYkI=>/dir/",
+			"<thunk H82kT-1VQQY=: (./file)>/dir/",
 		},
 	} {
 		t.Run(fmt.Sprintf("%T", test.src), func(t *testing.T) {

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -2,9 +2,7 @@ package runtimes
 
 import (
 	"context"
-	"crypto/sha256"
 	"embed"
-	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -203,12 +201,12 @@ func (runtime *Buildkit) Run(ctx context.Context, thunk bass.Thunk) error {
 }
 
 func (runtime *Buildkit) Read(ctx context.Context, w io.Writer, thunk bass.Thunk) error {
-	sha2, err := thunk.SHA256()
+	hash, err := thunk.Hash()
 	if err != nil {
 		return err
 	}
 
-	tmp, err := os.MkdirTemp("", "thunk-"+sha2)
+	tmp, err := os.MkdirTemp("", "thunk-"+hash)
 	if err != nil {
 		return err
 	}
@@ -429,7 +427,7 @@ func (b *builder) llb(ctx context.Context, thunk bass.Thunk, captureStdout bool)
 		return llb.ExecState{}, "", false, err
 	}
 
-	id, err := thunk.SHA256()
+	id, err := thunk.Hash()
 	if err != nil {
 		return llb.ExecState{}, "", false, err
 	}
@@ -795,11 +793,6 @@ func (b *builder) initializeMount(ctx context.Context, source bass.ThunkMountSou
 	}
 
 	return nil, "", false, fmt.Errorf("unrecognized mount source: %s", source.ToValue())
-}
-
-func hash(s string) string {
-	sum := sha256.Sum256([]byte(s))
-	return base64.URLEncoding.EncodeToString(sum[:])
 }
 
 type nopCloser struct {

--- a/pkg/runtimes/command.go
+++ b/pkg/runtimes/command.go
@@ -205,7 +205,7 @@ func (cmd *Command) resolveValue(val bass.Value, dest any) error {
 	var artifact bass.ThunkPath
 	if err := val.Decode(&artifact); err == nil {
 		// TODO: it might be worth mounting the entire artifact directory instead
-		name, err := artifact.Thunk.SHA256()
+		name, err := artifact.Thunk.Hash()
 		if err != nil {
 			return err
 		}
@@ -235,7 +235,7 @@ func (cmd *Command) resolveValue(val bass.Value, dest any) error {
 	var host bass.HostPath
 	if err := val.Decode(&host); err == nil {
 		target, err := bass.DirPath{
-			Path: hash(host.ContextDir),
+			Path: host.Hash(),
 		}.Extend(host.Path.FilesystemPath())
 		if err != nil {
 			return err
@@ -286,13 +286,13 @@ func (cmd *Command) resolveValue(val bass.Value, dest any) error {
 
 	var embedPath *bass.FSPath
 	if err := val.Decode(&embedPath); err == nil {
-		sha2, err := embedPath.SHA256()
+		hash, err := embedPath.Hash()
 		if err != nil {
 			return err
 		}
 
 		target, err := bass.DirPath{
-			Path: sha2,
+			Path: hash,
 		}.Extend(embedPath.Path.FilesystemPath())
 		if err != nil {
 			return err

--- a/pkg/runtimes/command_test.go
+++ b/pkg/runtimes/command_test.go
@@ -33,7 +33,7 @@ var thunkName string
 
 func init() {
 	var err error
-	thunkName, err = thunk.SHA256()
+	thunkName, err = thunk.Hash()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The main motivation here is UX (shorter identifiers), not performance, though xxh3 is much faster for this use case so I figured I'd try it out.

```
$ bass
=> (.foo)


        ██████
      ██████████
      ██████████
    ██  ██████  ██
      ██████████
      ██  ██  ██
    ██          ██
      ██      ██

<thunk huuCt5LNZ50=: (.foo)>
=> (path-name (.foo))
"huuCt5LNZ50="
```

Note: xxh3 is a non-cryptographic hash function. I don't think we need cryptographic properties given how thunk hashes are used:

* keys in maps for tracking already-loaded Bass modules
* directory names for thunk paths that are passed in to another thunk in args/env/stdin
* stringifying the thunk value in the REPL
* urls in [Bass Loop](https://loop.bass-lang.org/thunks/4Y0gY0kNeOtNuJCwcztudsMdUBl2sI652WDjuAs0dvE=)
* showing it in the page/tab title
* the hostname of the thunk's container. sidenote: this is what allows labels to bust caches.
* filenames for cached thunk path exports used for loading Bass source code from a thunk (e.g. `git clone` of a remote lib)
* filenames for cached thunk path exports used for rendering backtraces
* filenames for tmpdirs created by the buildkit runtime during read/export
* html `id=` tags in the docs
* the thunk's `(path-name)` and `(path-stem)`

Seems worth noting that secret values contained within a thunk do not influence the thunk's hash:

```
=> (.foo (mask "yo" :hey))


      ██  ██  ██
      ██████████
    ██  ██████  ██
    ██  ██████  ██
      ██████████
        ██  ██
      ████  ████


<thunk 3OTbj4nXlkM=: (.foo)>
=> (.foo (mask "yoo" :hey))


      ██  ██  ██
      ██████████
    ██  ██████  ██
    ██  ██████  ██
      ██████████
        ██  ██
      ████  ████


<thunk 3OTbj4nXlkM=: (.foo)>
=> (json (.foo (mask "yoo" :hey)))
"{\"cmd\":{\"command\":{\"name\":\"foo\"}},\"stdin\":[{\"secret\":{\"name\":\"hey\"}}]}"
```