### PR TITLE
cache fs/thunk paths to more useful filenames

### DIFF
--- a/pkg/bass/cache_path.go
+++ b/pkg/bass/cache_path.go
@@ -2,8 +2,6 @@ package bass
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -44,9 +42,7 @@ func (value CachePath) String() string {
 
 // Hash returns a non-cryptographic hash of the cache path's ID.
 func (value CachePath) Hash() string {
-	var sum [8]byte
-	binary.BigEndian.PutUint64(sum[:], xxh3.HashString(value.ID))
-	return base64.URLEncoding.EncodeToString(sum[:])
+	return b64(xxh3.HashString(value.ID))
 }
 
 func (value CachePath) Equal(other Value) bool {

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -108,6 +108,7 @@ func (combiner *FSPath) Call(ctx context.Context, val Value, scope *Scope, cont 
 var _ Path = (*FSPath)(nil)
 
 func (path *FSPath) Name() string {
+	// TODO: should this special-case ./ to return the path hash?
 	return path.Path.FilesystemPath().Name()
 }
 
@@ -131,7 +132,7 @@ func (fsp *FSPath) CachePath(ctx context.Context, dest string) (string, error) {
 		return "", err
 	}
 
-	return Cache(ctx, filepath.Join(dest, "fs", hash), fsp)
+	return Cache(ctx, filepath.Join(dest, "fs", hash, fsp.Path.FilesystemPath().FromSlash()), fsp)
 }
 
 func (fsp *FSPath) Open(ctx context.Context) (io.ReadCloser, error) {

--- a/pkg/bass/host_path.go
+++ b/pkg/bass/host_path.go
@@ -2,8 +2,6 @@ package bass
 
 import (
 	"context"
-	"encoding/base64"
-	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -51,9 +49,7 @@ func (value HostPath) String() string {
 
 // Hash returns a non-cryptographic hash of the host path's context dir.
 func (value HostPath) Hash() string {
-	var sum [8]byte
-	binary.BigEndian.PutUint64(sum[:], xxh3.HashString(value.ContextDir))
-	return base64.URLEncoding.EncodeToString(sum[:])
+	return b64(xxh3.HashString(value.ContextDir))
 }
 
 func (value HostPath) Equal(other Value) bool {


### PR DESCRIPTION
this way the editor can correctly determine the file type when used for go-to-definition

note: you'll probably have to clear `~/.cache/bass` since now some paths that previously were files need to be directories