### PR TITLE
add `(binds? scope sym)`

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -774,6 +774,10 @@ func init() {
 		Func("cache-dir", "[id]", NewCacheDir),
 		`returns a cache directory corresponding to the string identifier`,
 		`Cache directories may be mounted to thunks. Their content persists across thunk runs.`)
+
+	Ground.Set("binds?",
+		Func("binds?", "[scope sym]", (*Scope).Binds),
+		`returns true if the scope has a value bound to the given symbol`)
 }
 
 type primPred struct {

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -907,6 +907,21 @@ func TestGroundScope(t *testing.T) {
 			Result: bass.NewList(bass.Bool(false), bass.Int(2)),
 		},
 		{
+			Name:   "binds? bound",
+			Bass:   `(binds? {:a 1 :b 2} :a)`,
+			Result: bass.Bool(true),
+		},
+		{
+			Name:   "binds? not bound",
+			Bass:   `(binds? {:a 1 :b 2} :c)`,
+			Result: bass.Bool(false),
+		},
+		{
+			Name:   "binds? bound in parent",
+			Bass:   `(binds? {:a 1 {:b 2}} :b)`,
+			Result: bass.Bool(true),
+		},
+		{
 			Name: "provide",
 			Bass: `(def foo :outer)
 

--- a/pkg/bass/scope.go
+++ b/pkg/bass/scope.go
@@ -383,6 +383,12 @@ func (scope *Scope) GetDecode(binding Symbol, dest any) error {
 	return val.Decode(dest)
 }
 
+// Binds returns true if the scope provides the given binding.
+func (scope *Scope) Binds(binding Symbol) bool {
+	_, found := scope.Get(binding)
+	return found
+}
+
 // Complete queries the scope for bindings beginning with the given prefix.
 //
 // Local bindings are listed before parent bindings, with shorter binding names

--- a/pkg/lsp/lsp_test.go
+++ b/pkg/lsp/lsp_test.go
@@ -36,7 +36,7 @@ func testFile(t *testing.T, client *nvim.Nvim, file string) {
 		var b bool
 		err := client.Eval(`luaeval('#vim.lsp.buf_get_clients() > 0')`, &b)
 		return err == nil && b
-	}, time.Second, 10*time.Millisecond)
+	}, 5*time.Second, 10*time.Millisecond)
 
 	lineCount, err := client.BufferLineCount(testBuf)
 	is.NoErr(err)
@@ -113,7 +113,7 @@ func testFile(t *testing.T, client *nvim.Nvim, file string) {
 			t.Logf("L%03d %s\tmatched: %s", testLine, codes, eq[1])
 
 			return true
-		}, 1*time.Second, 10*time.Millisecond)
+		}, 5*time.Second, 10*time.Millisecond)
 
 		// go back from definition to initial test buffer
 		err = client.SetCurrentBuffer(testBuf)


### PR DESCRIPTION
Per the tin - a simple predicate for testing whether a scope contains a binding.

Decided to match the arg order to Racket's `(dict-has-key? dict key)` and Clojure's `(contains? coll key)`.

I'm keeping this function specific to scopes though, as opposed to Clojure's `contains?` which works against any collection type. `contains?` when added will likely be specific to lists. If `contains?` worked against scopes it would probably not work the way you'd expect; if I want to make `(map)` work on scopes it'd mean having scopes convertable to a list but that would have to be a list of pairs, not a list of keys like `contains?` would expect.