### PR TITLE
add `(when test & body)`

### DIFF
--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -1213,6 +1213,35 @@ func TestGroundBoolean(t *testing.T) {
 			Bass:   `(and)`,
 			Result: bass.Bool(true),
 		},
+		{
+			Name:   "when true",
+			Bass:   "(when true (def x sentinel) x)",
+			Result: sentinel,
+			Bindings: bass.Bindings{
+				"sentinel": sentinel,
+				"x":        sentinel,
+			},
+		},
+		{
+			Name:   "when false",
+			Bass:   "(when false unevaluated)",
+			Result: bass.Null{},
+		},
+		{
+			Name:   "when null",
+			Bass:   "(when null unevaluated)",
+			Result: bass.Null{},
+		},
+		{
+			Name:   "when empty",
+			Bass:   "(when [] sentinel)",
+			Result: sentinel,
+		},
+		{
+			Name:   "when string",
+			Bass:   `(when "" sentinel)`,
+			Result: sentinel,
+		},
 	} {
 		t.Run(test.Name, func(t *testing.T) {
 			is := is.New(t)

--- a/std/root.bass
+++ b/std/root.bass
@@ -534,3 +534,9 @@
 ; => (run (from (linux/alpine) ($ echo "Hello, world!")))
 (defn run [thunk]
   ((start thunk (fn [err] (and err (err))))))
+
+; runs the body if test returns true
+;
+; Returns the body's result, or null if the test is false.
+(defop when [test & body] scope
+  (eval [if test [do & body] null] scope))


### PR DESCRIPTION
Per the tin - a form of `(if)` that only takes the truthy side as a body (rather than a single form) and returns `null` if the test is false.