### PR TITLE
lima-bass-templating

### DIFF
--- a/lima/bass.yaml
+++ b/lima/bass.yaml
@@ -32,6 +32,6 @@ portForwards:
   hostSocket: "{{.Home}}/Library/Application Support/bass/buildkitd.sock"
 
 message: |
-  forwarded buildkitd socket to {{.Home}}/.config/bass/buildkitd.sock
+  forwarded buildkitd socket to $HOME/Library/Application Support/bass/buildkitd.sock
 
-  `bass' will automatically discover it there - start playing!
+  `bass` will automatically discover it there - start playing!


### PR DESCRIPTION
this change resolved this error for me:

```sh
> limactl start ./lima/bass.yaml
? Creating an instance "bass" Proceed with the current configuration
FATA[0004] errors inspecting instance: [cannot execute template "forwarded buildkitd socket to {{.Home}}/.config/bass/buildkitd.sock\n\n`bass' will automatically discover it there - start playing!\n": template: format:1:32: executing "format" at <.Home>: can't evaluate field Home in type store.FormatData]
```

a little sad that the `message` field can't seem to print out exactly where `buildkitd.sock` is, though :(