### PR TITLE
auto-start `buildkitd` in Docker if not configured

### DIFF
--- a/bass/bass.bass
+++ b/bass/bass.bass
@@ -49,7 +49,7 @@
       ($ cp src/go.mod src/go.sum ./)
       ($ go mod download))))
 
-(provide [build smoke-test tests docs]
+(provide [build smoke-test tests docs coverage]
   ; compiles a bass binary for the given platform and puts it in an archive
   (defn build [src version os arch]
     (let [staged (with-shims
@@ -123,8 +123,8 @@
     (map (fn [image] (check-dist dist image))
          smoke-tests))
 
-  (defn with-deps [src test-thunk]
-    (-> test-thunk
+  (defn with-deps [thunk src]
+    (-> thunk
         (wrap-cmd ./hack/with-deps) ; TODO: maybe swap the order here
         (with-shims src)
         ; runtime tests currently need elevated privileges
@@ -132,21 +132,23 @@
 
   ; returns a directory containing the built docs HTML
   (defn docs [src]
-    (subpath
-      (with-deps src
-        ($ ./docs/scripts/build))
-      ./docs/))
+    (-> ($ ./docs/scripts/build)
+        (with-deps src)
+        (subpath ./docs/)))
+
+  ; returns a thunk that runs the tests
+  (defn tests [src testflags]
+    (-> ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
+           --
+           -cover
+           -coverprofile ./cover.out
+           -covermode count
+           & $testflags)
+        (with-deps src)))
 
   ; returns a thunk that will run the tests and return cover.html
-  (defn tests [src testflags]
-    (from (with-deps src
-            ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
-               --
-               -cover
-               -coverprofile ./cover.out
-               -covermode count
-               & $testflags))
-
+  (defn coverage [src testflags]
+    (from (tests src testflags)
       ; report slow tests
       ($ gotestsum tool slowest --jsonfile ./tests.log --threshold "500ms")
 

--- a/bass/docs
+++ b/bass/docs
@@ -1,7 +1,8 @@
 #!/usr/bin/env bass
 
+(use (*dir*/bass.bass))
+
 ; emits the built docs to stdout
 (defn main []
   (for [{:src src} *stdin*]
-    (use (src/project))
-    (emit (project:docs src) *stdout*)))
+    (emit (bass:docs src) *stdout*)))

--- a/bass/test
+++ b/bass/test
@@ -7,7 +7,7 @@
 ; Emits code coverage to *stdout*.
 (defn main testflags
   (for [{:src src} *stdin*]
-    (let [tests (bass:tests src ["./..." & testflags])]
+    (let [tests (bass:coverage src ["./..." & testflags])]
       (log "running tests")
       (run tests)
       (emit {:coverage tests/cover.html} *stdout*))))

--- a/cmd/bass/lsp.go
+++ b/cmd/bass/lsp.go
@@ -39,7 +39,7 @@ func langServer(ctx context.Context) error {
 
 	ctx = ioctx.StderrToContext(ctx, logDest)
 
-	pool, err := runtimes.NewPool(&bass.Config{
+	pool, err := runtimes.NewPool(ctx, &bass.Config{
 		// no runtimes; language server must be effect free
 		Runtimes: nil,
 	})

--- a/cmd/bass/main.go
+++ b/cmd/bass/main.go
@@ -86,7 +86,6 @@ var DefaultConfig = bass.Config{
 		{
 			Platform: bass.LinuxPlatform,
 			Runtime:  runtimes.BuildkitName,
-			Addrs:    runtimes.DefaultBuildkitAddrs,
 		},
 	},
 }

--- a/cmd/bass/main.go
+++ b/cmd/bass/main.go
@@ -132,7 +132,7 @@ func root(ctx context.Context) error {
 		return err
 	}
 
-	pool, err := runtimes.NewPool(config)
+	pool, err := runtimes.NewPool(ctx, config)
 	if err != nil {
 		cli.WriteError(ctx, err)
 		return err

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -334,7 +334,7 @@ func initBassCtx() (context.Context, error) {
 
 	var err error
 	runtimeOnce.Do(func() {
-		runtimePool, err = runtimes.NewPool(&bass.Config{
+		runtimePool, err = runtimes.NewPool(ctx, &bass.Config{
 			Runtimes: []bass.RuntimeConfig{
 				{
 					Runtime:  runtimes.BuildkitName,

--- a/docs/go/bass.go
+++ b/docs/go/bass.go
@@ -339,7 +339,6 @@ func initBassCtx() (context.Context, error) {
 				{
 					Runtime:  runtimes.BuildkitName,
 					Platform: bass.LinuxPlatform,
-					Addrs:    runtimes.DefaultBuildkitAddrs,
 					Config: bass.Bindings{
 						"disable_cache": bass.Bool(os.Getenv("DISABLE_CACHE") != ""),
 					}.Scope(),

--- a/docs/lit/guide.lit
+++ b/docs/lit/guide.lit
@@ -13,51 +13,23 @@ for common tasks. If you'd like to learn the language, see \reference{bassics}.
   binary}{https://github.com/vito/bass/releases/latest} which needs to be
   installed somewhere in your \code{$PATH}.
 
-  Bass runs thunks using \link{Buildkit}{https://github.com/moby/buildkit}, so
-  you'll need \code{buildkitd} running somewhere, somehow. At the moment you'll
-  probably need some bits and bobs from the \link{Bass
-  repo}{https://github.com/vito/bass}:
+  To run Bass you'll need either \link{Docker
+  Engine}{https://docs.docker.com/engine/install/#server} (\bold{Linux}),
+  \link{Docker Desktop}{https://www.docker.com/products/docker-desktop/}
+  (\bold{OS X}, \bold{Windows}), or
+  \link{Buildkit}{https://github.com/moby/buildkit} running.
 
-  \commands{{{
-    git clone https://github.com/vito/bass
-    cd bass
-  }}}
-
-  If you're on \bold{Linux}, install \code{buildkitd} somewhere in your
-  \code{$PATH}. If you know how to wire it up as system daemon, go ahead
-  and do that - otherwise you can use the \code{./hack/buildkit/}
-  helpers:
-
-  \commands{{{
-    ./hack/buildkit/start
-    ./hack/buildkit/stop # i usually just leave it running
-  }}}
-
-  If you're on \bold{macOS} you can use
-  \link{\code{lima/bass.yaml}}{https://github.com/vito/bass/blob/main/lima/bass.yaml}
-  to manage a Linux VM using
-  \link{\code{limactl}}{https://github.com/lima-vm/lima}:
-
-  \commands{{{
-    brew install lima
-    limactl start ./lima/bass.yaml
-  }}}
-
-  If you're on \bold{Windows}, follow the Linux instructions in WSL2. Native
-  Windows support should be possible once Buildkit supports it.
-
-  With everything set up, try out one of the demos:
+  With everything installed, try one of the demos:
 
   \commands{{{
     bass demos/git-lib.bass
   }}}
 
-  If you see a cryptic socket error, \code{buildkitd} probably isn't running.
   If you see \code{bass: command not found}, it's not in your \code{$PATH}.
 
-  Ask for help in
+  If you see some other kind of error you're welcome to ask for help in
   \link{GitHub}{https://github.com/vito/bass/discussions/categories/q-a} or
-  \link{Discord}{https://discord.gg/HFW85RyUtK} if you get stuck!
+  \link{Discord}{https://discord.gg/HFW85RyUtK}.
 
   \section{
     \title{running thunks}

--- a/go.mod
+++ b/go.mod
@@ -16,9 +16,10 @@ require (
 	github.com/google/go-cmp v0.5.7
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/jonboulle/clockwork v0.2.2
-	github.com/mattn/go-colorable v0.1.8
+	github.com/mattn/go-colorable v0.1.12
 	github.com/mattn/go-isatty v0.0.14
 	github.com/mattn/go-unicodeclass v0.0.1
+	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/buildkit v0.10.3
 	github.com/moby/sys/mountinfo v0.6.0
 	github.com/morikuni/aec v1.0.0
@@ -29,6 +30,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/protocolbuffers/txtpbfmt v0.0.0-20220608084003-fc78c767cd6a
 	github.com/psanford/memfs v0.0.0-20210214183328-a001468d78ef
+	github.com/rs/zerolog v1.27.0
 	github.com/segmentio/textio v1.2.0
 	github.com/sourcegraph/jsonrpc2 v0.1.0
 	github.com/spf13/pflag v1.0.5
@@ -40,6 +42,7 @@ require (
 	github.com/vito/progrock v0.0.0-20220404031818-4f9564b3a350
 	github.com/vito/vt100 v0.0.0-20220404031632-f6fec6525a40
 	github.com/zeebo/xxh3 v1.0.2
+	go.opentelemetry.io/otel v1.4.1
 	go.uber.org/zap v1.19.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
@@ -99,7 +102,6 @@ require (
 	github.com/tonistiigi/vt100 v0.0.0-20210615222946-8066bb97264f // indirect
 	github.com/vbatts/go-mtree v0.5.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.29.0 // indirect
-	go.opentelemetry.io/otel v1.4.1 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.4.1 // indirect
 	go.opentelemetry.io/otel/sdk v1.4.1 // indirect
 	go.opentelemetry.io/otel/trace v1.4.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,7 @@ github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
+github.com/coreos/go-systemd/v22 v22.3.3-0.20220203105225-a9a7ef127534/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
@@ -252,8 +253,8 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
-github.com/mattn/go-colorable v0.1.8 h1:c1ghPdyEDarC70ftn0y+A/Ee++9zz8ljHG1b13eJ0s8=
-github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.12 h1:jF+Du6AlPIjs2BiUiQlKOX0rt3SujHxPnksPKZbaA40=
+github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.10/go.mod h1:qgIWMr58cqv1PHHyhnkY9lrL7etaEgOFcMEpPG5Rm84=
@@ -274,6 +275,7 @@ github.com/mattn/go-unicodeclass v0.0.1 h1:BKdh58FOa0n4QRd39jSeVEF7ncxxV3l4GL05L
 github.com/mattn/go-unicodeclass v0.0.1/go.mod h1:dDCkCgOKUwD3sYX4N+tVQdFh/xlFQ1+cWakbQzy98T8=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b/go.mod h1:01TrycV0kFyexm33Z7vhZRXopbI8J3TDReVlkTgMUxE=
+github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-wordwrap v1.0.1 h1:TLuKupo69TCn6TQSyGxwI1EblZZEsQ0vMlAFQflz0v0=
 github.com/mitchellh/go-wordwrap v1.0.1/go.mod h1:R62XHJLzvMFRBbcrT7m7WgmE1eOyTSsCt+hzestvNj0=
@@ -367,6 +369,9 @@ github.com/rogpeppe/fastuuid v1.1.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
+github.com/rs/xid v1.3.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
+github.com/rs/zerolog v1.27.0 h1:1T7qCieN22GVc8S4Q2yuexzBb1EqjbgjSH9RohbMjKs=
+github.com/rs/zerolog v1.27.0/go.mod h1:7frBqO0oezxmnO7GF86FY++uy8I0Tk/If5ni1G9Qc0U=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=
@@ -571,6 +576,7 @@ golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211019181941-9d821ace8654/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/hack/bump-buildkit
+++ b/hack/bump-buildkit
@@ -14,3 +14,6 @@ tag="$1"
   tar -xf -
 
 go mod tidy
+
+sed -i -e 's/const Version = .*/const Version = "'$tag'"/g' \
+  pkg/runtimes/util/buildkitd/buildkitd.go

--- a/nix/vendorSha256.txt
+++ b/nix/vendorSha256.txt
@@ -1,1 +1,1 @@
-sha256-ee675i1cCL78hHCQM6zQXy16rygOcco1lW7puvJdRSY=
+sha256-3cMsNBQGJrX3WvhHbxRwr0SMsEXi+UcfekBM3xQBU38=

--- a/pkg/bass/config.go
+++ b/pkg/bass/config.go
@@ -1,9 +1,7 @@
 package bass
 
 import (
-	"encoding/json"
 	"fmt"
-	"net/url"
 	"os"
 
 	"github.com/adrg/xdg"
@@ -20,44 +18,9 @@ type Config struct {
 // Additional configuration may be specified; it will be read from the runtime
 // by finding the config associated to the platform on the thunk it receives.
 type RuntimeConfig struct {
-	Platform Platform     `json:"platform"`
-	Runtime  string       `json:"runtime"`
-	Addrs    RuntimeAddrs `json:"addrs,omitempty"`
-	Config   *Scope       `json:"config,omitempty"`
-}
-
-// RuntimeAddrs contains addresses of various services.
-type RuntimeAddrs map[string]*url.URL
-
-func (addrs RuntimeAddrs) Service(name string) (*url.URL, bool) {
-	if addrs == nil {
-		return nil, false
-	}
-
-	u, found := addrs[name]
-	return u, found
-}
-
-func (addrs *RuntimeAddrs) UnmarshalJSON(p []byte) error {
-	newAddrs := make(map[string]*url.URL)
-
-	var m map[string]string
-	if err := json.Unmarshal(p, &m); err != nil {
-		return fmt.Errorf("malformed addrs: %w", err)
-	}
-
-	for name, urlStr := range m {
-		u, err := url.Parse(urlStr)
-		if err != nil {
-			return fmt.Errorf("addr %q: %w", name, err)
-		}
-
-		newAddrs[name] = u
-	}
-
-	*addrs = newAddrs
-
-	return nil
+	Platform Platform `json:"platform"`
+	Runtime  string   `json:"runtime"`
+	Config   *Scope   `json:"config,omitempty"`
 }
 
 // LoadConfig loads a Config from the JSON file at the given path.

--- a/pkg/bass/session_test.go
+++ b/pkg/bass/session_test.go
@@ -20,7 +20,8 @@ import (
 func TestBass(t *testing.T) {
 	is := is.New(t)
 
-	pool, err := runtimes.NewPool(&bass.Config{})
+	ctx := context.Background()
+	pool, err := runtimes.NewPool(ctx, &bass.Config{})
 	is.NoErr(err)
 
 	for _, test := range []struct {

--- a/pkg/runtimes/buildkit_test.go
+++ b/pkg/runtimes/buildkit_test.go
@@ -21,7 +21,6 @@ func TestBuildkitRuntime(t *testing.T) {
 			{
 				Platform: bass.LinuxPlatform,
 				Runtime:  runtimes.BuildkitName,
-				Addrs:    runtimes.DefaultBuildkitAddrs,
 			},
 		},
 	})

--- a/pkg/runtimes/buildkit_test.go
+++ b/pkg/runtimes/buildkit_test.go
@@ -1,8 +1,10 @@
 package runtimes_test
 
 import (
+	"context"
 	"testing"
 
+	_ "github.com/moby/buildkit/client"
 	"github.com/vito/bass/pkg/bass"
 	"github.com/vito/bass/pkg/runtimes"
 	"github.com/vito/is"
@@ -16,7 +18,9 @@ func TestBuildkitRuntime(t *testing.T) {
 		return
 	}
 
-	pool, err := runtimes.NewPool(&bass.Config{
+	ctx := context.Background()
+
+	pool, err := runtimes.NewPool(ctx, &bass.Config{
 		Runtimes: []bass.RuntimeConfig{
 			{
 				Platform: bass.LinuxPlatform,

--- a/pkg/runtimes/pool.go
+++ b/pkg/runtimes/pool.go
@@ -1,6 +1,7 @@
 package runtimes
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/hashicorp/go-multierror"
@@ -18,18 +19,14 @@ type Assoc struct {
 	Runtime  bass.Runtime
 }
 
-// Pool is a 'union' runtime which delegates each call to the appropriate
-// runtime based on the Thunk's platform.
-// var _ bass.Runtime = &Pool{}
-
 // NewPool initializes all runtimes in the given configuration.
-func NewPool(config *bass.Config) (*Pool, error) {
+func NewPool(ctx context.Context, config *bass.Config) (*Pool, error) {
 	pool := &Pool{}
 
 	for _, config := range config.Runtimes {
-		runtime, err := Init(config.Runtime, pool, config.Config)
+		runtime, err := Init(ctx, config.Runtime, pool, config.Config)
 		if err != nil {
-			return nil, fmt.Errorf("init runtime for platform %s: %w", config.Platform, err)
+			return nil, fmt.Errorf("init %s runtime for platform %s: %w", config.Runtime, config.Platform, err)
 		}
 
 		pool.Runtimes = append(pool.Runtimes, Assoc{

--- a/pkg/runtimes/pool.go
+++ b/pkg/runtimes/pool.go
@@ -27,9 +27,9 @@ func NewPool(config *bass.Config) (*Pool, error) {
 	pool := &Pool{}
 
 	for _, config := range config.Runtimes {
-		runtime, err := Init(config, pool)
+		runtime, err := Init(config.Runtime, pool, config.Config)
 		if err != nil {
-			return nil, fmt.Errorf("init %s runtime for platform %s: %w", config.Runtime, config.Platform, err)
+			return nil, fmt.Errorf("init runtime for platform %s: %w", config.Platform, err)
 		}
 
 		pool.Runtimes = append(pool.Runtimes, Assoc{

--- a/pkg/runtimes/registry.go
+++ b/pkg/runtimes/registry.go
@@ -1,11 +1,15 @@
 package runtimes
 
-import "github.com/vito/bass/pkg/bass"
+import (
+	"context"
+
+	"github.com/vito/bass/pkg/bass"
+)
 
 var runtimes = map[string]InitFunc{}
 
 // InitFunc is a Runtime constructor.
-type InitFunc func(bass.RuntimePool, *bass.Scope) (bass.Runtime, error)
+type InitFunc func(context.Context, bass.RuntimePool, *bass.Scope) (bass.Runtime, error)
 
 // Register installs a runtime under a given name.
 //
@@ -16,7 +20,7 @@ func RegisterRuntime(name string, init InitFunc) {
 }
 
 // Init initializes the runtime registered under the given name.
-func Init(name string, pool bass.RuntimePool, config *bass.Scope) (bass.Runtime, error) {
+func Init(ctx context.Context, name string, pool bass.RuntimePool, config *bass.Scope) (bass.Runtime, error) {
 	init, found := runtimes[name]
 	if !found {
 		return nil, UnknownRuntimeError{
@@ -24,5 +28,5 @@ func Init(name string, pool bass.RuntimePool, config *bass.Scope) (bass.Runtime,
 		}
 	}
 
-	return init(pool, config)
+	return init(ctx, pool, config)
 }

--- a/pkg/runtimes/registry.go
+++ b/pkg/runtimes/registry.go
@@ -5,7 +5,7 @@ import "github.com/vito/bass/pkg/bass"
 var runtimes = map[string]InitFunc{}
 
 // InitFunc is a Runtime constructor.
-type InitFunc func(bass.RuntimePool, bass.RuntimeAddrs, *bass.Scope) (bass.Runtime, error)
+type InitFunc func(bass.RuntimePool, *bass.Scope) (bass.Runtime, error)
 
 // Register installs a runtime under a given name.
 //
@@ -16,13 +16,13 @@ func RegisterRuntime(name string, init InitFunc) {
 }
 
 // Init initializes the runtime registered under the given name.
-func Init(config bass.RuntimeConfig, pool bass.RuntimePool) (bass.Runtime, error) {
-	init, found := runtimes[config.Runtime]
+func Init(name string, pool bass.RuntimePool, config *bass.Scope) (bass.Runtime, error) {
+	init, found := runtimes[name]
 	if !found {
 		return nil, UnknownRuntimeError{
-			Name: config.Runtime,
+			Name: name,
 		}
 	}
 
-	return init(pool, config.Addrs, config.Config)
+	return init(pool, config)
 }

--- a/pkg/runtimes/util/buildkitd/LICENSE
+++ b/pkg/runtimes/util/buildkitd/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/pkg/runtimes/util/buildkitd/NOTICE
+++ b/pkg/runtimes/util/buildkitd/NOTICE
@@ -1,0 +1,16 @@
+Dagger
+Copyright 2012-2017 Dagger, Inc.
+
+This product includes software developed at Dagger, Inc. (https://www.dagger.io).
+
+The following is courtesy of our legal counsel:
+
+
+Use and transfer of Dagger may be subject to certain restrictions by the
+United States and other governments.
+It is your responsibility to ensure that your use and/or transfer does not
+violate applicable laws.
+
+For more information, please see https://www.bis.doc.gov
+
+See also https://www.apache.org/dev/crypto.html and/or seek legal counsel.

--- a/pkg/runtimes/util/buildkitd/README.md
+++ b/pkg/runtimes/util/buildkitd/README.md
@@ -7,3 +7,4 @@ Originally extracted from Dagger. LICENSE and NOTICE preserved verbatim.
 * `:%s/dagger/bass/g`
 * replace `vendoredVersion` with `const Version` updated by bump script, since
   build info isn't available for tests
+* insecure entitlement enabled (may reconsider this later)

--- a/pkg/runtimes/util/buildkitd/README.md
+++ b/pkg/runtimes/util/buildkitd/README.md
@@ -1,0 +1,9 @@
+# util
+
+Originally extracted from Dagger. LICENSE and NOTICE preserved verbatim.
+
+## modifications
+
+* `:%s/dagger/bass/g`
+* replace `vendoredVersion` with `const Version` updated by bump script, since
+  build info isn't available for tests

--- a/pkg/runtimes/util/buildkitd/buildkit_information.go
+++ b/pkg/runtimes/util/buildkitd/buildkit_information.go
@@ -1,0 +1,62 @@
+package buildkitd
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"github.com/docker/distribution/reference"
+)
+
+func getBuildkitInformation(ctx context.Context) (*BuildkitInformation, error) {
+	formatString := "{{.Config.Image}};{{.State.Running}};{{if index .NetworkSettings.Networks \"host\"}}{{\"true\"}}{{else}}{{\"false\"}}{{end}}"
+	cmd := exec.CommandContext(ctx,
+		"docker",
+		"inspect",
+		"--format",
+		formatString,
+		containerName,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, err
+	}
+
+	s := strings.Split(string(output), ";")
+
+	// Retrieve the tag
+	ref, err := reference.ParseNormalizedNamed(strings.TrimSpace(s[0]))
+	if err != nil {
+		return nil, err
+	}
+	tag, ok := ref.(reference.Tagged)
+	if !ok {
+		return nil, fmt.Errorf("failed to parse image: %s", output)
+	}
+
+	// Retrieve the state
+	isActive, err := strconv.ParseBool(strings.TrimSpace(s[1]))
+	if err != nil {
+		return nil, err
+	}
+
+	// Retrieve the check on if the host network is configured
+	haveHostNetwork, err := strconv.ParseBool(strings.TrimSpace(s[2]))
+	if err != nil {
+		return nil, err
+	}
+
+	return &BuildkitInformation{
+		Version:         tag.Tag(),
+		IsActive:        isActive,
+		HaveHostNetwork: haveHostNetwork,
+	}, nil
+}
+
+type BuildkitInformation struct {
+	Version         string
+	IsActive        bool
+	HaveHostNetwork bool
+}

--- a/pkg/runtimes/util/buildkitd/buildkitd.go
+++ b/pkg/runtimes/util/buildkitd/buildkitd.go
@@ -218,6 +218,7 @@ func installBuildkit(ctx context.Context) error {
 		"--privileged",
 		image+":"+Version,
 		"--debug",
+		"--allow-insecure-entitlement", "security.insecure",
 	)
 	output, err = cmd.CombinedOutput()
 	if err != nil {

--- a/pkg/runtimes/util/buildkitd/buildkitd.go
+++ b/pkg/runtimes/util/buildkitd/buildkitd.go
@@ -1,0 +1,287 @@
+package buildkitd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/mitchellh/go-homedir"
+	_ "github.com/moby/buildkit"
+	bk "github.com/moby/buildkit/client"
+	_ "github.com/moby/buildkit/client/connhelper/dockercontainer" // import the container connection driver
+	"github.com/rs/zerolog/log"
+	"go.opentelemetry.io/otel"
+)
+
+// bumped by hack/bump-buildkit
+const Version = "v0.10.3"
+
+const (
+	image         = "moby/buildkit"
+	containerName = "bass-buildkitd"
+	volumeName    = "bass-buildkitd"
+
+	buildkitdLockPath = "~/.config/bass/.buildkitd.lock"
+	// Long timeout to allow for slow image pulls of
+	// buildkitd while not blocking for infinity
+	lockTimeout = 10 * time.Minute
+)
+
+func Start(ctx context.Context) (string, error) {
+	ctx, span := otel.Tracer("bass").Start(ctx, "buildkitd.Start")
+	defer span.End()
+
+	if err := checkBuildkit(ctx); err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("docker-container://%s", containerName), nil
+}
+
+// ensure the buildkit is active and properly set up (e.g. connected to host and last version with moby/buildkit)
+func checkBuildkit(ctx context.Context) error {
+	lg := log.Ctx(ctx)
+
+	// acquire a file-based lock to ensure parallel bass clients
+	// don't interfere with checking+creating the buildkitd container
+	lockFilePath, err := homedir.Expand(buildkitdLockPath)
+	if err != nil {
+		return fmt.Errorf("unable to expand buildkitd lock path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(lockFilePath), 0755); err != nil {
+		return fmt.Errorf("unable to create buildkitd lock path parent dir: %w", err)
+	}
+	lock := flock.New(lockFilePath)
+	lg.Debug().Str("lockFilePath", lockFilePath).Msg("acquiring buildkitd lock")
+	lockCtx, cancel := context.WithTimeout(ctx, lockTimeout)
+	defer cancel()
+	locked, err := lock.TryLockContext(lockCtx, 100*time.Millisecond)
+	if err != nil {
+		return fmt.Errorf("failed to lock buildkitd lock file: %w", err)
+	}
+	if !locked {
+		return fmt.Errorf("failed to acquire buildkitd lock file")
+	}
+	defer lock.Unlock()
+	lg.Debug().Msg("acquired buildkitd lock")
+
+	// check status of buildkitd container
+	config, err := getBuildkitInformation(ctx)
+	if err != nil {
+		lg.
+			Debug().
+			Err(err).
+			Msg("failed to get buildkit information")
+
+		// If that failed, it might be because the docker CLI is out of service.
+		if err := checkDocker(ctx); err != nil {
+			return err
+		}
+
+		lg.Debug().Msg("no buildkit daemon detected")
+
+		if err := removeBuildkit(ctx); err != nil {
+			lg.Debug().Err(err).Msg("error while removing buildkit")
+		}
+
+		if err := installBuildkit(ctx); err != nil {
+			return err
+		}
+	} else {
+		lg.
+			Debug().
+			Str("version", config.Version).
+			Bool("isActive", config.IsActive).
+			Bool("haveHostNetwork", config.HaveHostNetwork).
+			Msg("detected buildkit config")
+
+		if config.Version != Version || !config.HaveHostNetwork {
+			lg.
+				Info().
+				Str("version", Version).
+				Bool("have host network", config.HaveHostNetwork).
+				Msg("upgrading buildkit")
+
+			if err := removeBuildkit(ctx); err != nil {
+				return err
+			}
+			if err := installBuildkit(ctx); err != nil {
+				return err
+			}
+		}
+		if !config.IsActive {
+			lg.
+				Info().
+				Str("version", Version).
+				Msg("starting buildkit")
+
+			if err := startBuildkit(ctx); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// ensure the docker CLI is available and properly set up (e.g. permissions to
+// communicate with the daemon, etc)
+func checkDocker(ctx context.Context) error {
+	cmd := exec.CommandContext(ctx, "docker", "info")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		log.
+			Ctx(ctx).
+			Error().
+			Err(err).
+			Bytes("output", output).
+			Msg("failed to run docker")
+		return err
+	}
+
+	return nil
+}
+
+// Start the buildkit daemon
+func startBuildkit(ctx context.Context) error {
+	lg := log.
+		Ctx(ctx).
+		With().
+		Str("version", Version).
+		Logger()
+
+	lg.Debug().Msg("starting buildkit image")
+
+	cmd := exec.CommandContext(ctx,
+		"docker",
+		"start",
+		containerName,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		lg.
+			Error().
+			Err(err).
+			Bytes("output", output).
+			Msg("failed to start buildkit container")
+		return err
+	}
+
+	return waitBuildkit(ctx)
+}
+
+// Pull and run the buildkit daemon with a proper configuration
+// If the buildkit daemon is already configured, use startBuildkit
+func installBuildkit(ctx context.Context) error {
+	lg := log.
+		Ctx(ctx).
+		With().
+		Str("version", Version).
+		Logger()
+
+	lg.Debug().Msg("pulling buildkit image")
+	// #nosec
+	cmd := exec.CommandContext(ctx,
+		"docker",
+		"pull",
+		image+":"+Version,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		lg.
+			Error().
+			Err(err).
+			Bytes("output", output).
+			Msg("failed to pull buildkit image")
+		return err
+	}
+
+	// FIXME: buildkitd currently runs without network isolation (--net=host)
+	// in order for containers to be able to reach localhost.
+	// This is required for things such as kubectl being able to
+	// reach a KinD/minikube cluster locally
+	// #nosec
+	cmd = exec.CommandContext(ctx,
+		"docker",
+		"run",
+		"--net=host",
+		"-d",
+		"--restart", "always",
+		"-v", volumeName+":/var/lib/buildkit",
+		"--name", containerName,
+		"--privileged",
+		image+":"+Version,
+		"--debug",
+	)
+	output, err = cmd.CombinedOutput()
+	if err != nil {
+		// If the daemon failed to start because it's already running,
+		// chances are another bass instance started it. We can just ignore
+		// the error.
+		if !strings.Contains(string(output), "Error response from daemon: Conflict.") {
+			log.
+				Ctx(ctx).
+				Error().
+				Err(err).
+				Bytes("output", output).
+				Msg("unable to start buildkitd")
+			return err
+		}
+	}
+	return waitBuildkit(ctx)
+}
+
+// waitBuildkit waits for the buildkit daemon to be responsive.
+func waitBuildkit(ctx context.Context) error {
+	c, err := bk.New(ctx, "docker-container://"+containerName)
+	if err != nil {
+		return err
+	}
+
+	// FIXME Does output "failed to wait: signal: broken pipe"
+	defer c.Close()
+
+	// Try to connect every 100ms up to 100 times (10 seconds total)
+	const (
+		retryPeriod   = 100 * time.Millisecond
+		retryAttempts = 100
+	)
+
+	for retry := 0; retry < retryAttempts; retry++ {
+		_, err = c.ListWorkers(ctx)
+		if err == nil {
+			return nil
+		}
+		time.Sleep(retryPeriod)
+	}
+	return errors.New("buildkit failed to respond")
+}
+
+func removeBuildkit(ctx context.Context) error {
+	lg := log.
+		Ctx(ctx)
+
+	cmd := exec.CommandContext(ctx,
+		"docker",
+		"rm",
+		"-fv",
+		containerName,
+	)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		lg.
+			Error().
+			Err(err).
+			Bytes("output", output).
+			Msg("failed to stop buildkit")
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This should make it much much easier to get started with Bass; just install Docker and it'll run its own Buildkit daemon if you don't have one configured.

This is based on Dagger's [`util/buildkitd`](https://github.com/dagger/dagger/blob/main/util/buildkitd/buildkitd.go). 🙏Original license and copyright notice preserved.