### PR TITLE
add `bass --run` for running thunk JSON passed on stdin

### DIFF
--- a/cmd/bass/main.go
+++ b/cmd/bass/main.go
@@ -25,6 +25,7 @@ var cmdline = strings.Join(os.Args, " ")
 
 var inputs []string
 
+var runRun bool
 var runExport bool
 var bumpLock string
 var runPrune bool
@@ -47,6 +48,7 @@ func init() {
 	flags.StringSliceVarP(&inputs, "input", "i", nil, "inputs to encode as JSON on *stdin*, name=value; value may be a path")
 
 	flags.BoolVarP(&runExport, "export", "e", false, "write a thunk path to stdout as a tar stream, or log the tar contents if stdout is a tty")
+	flags.BoolVar(&runRun, "run", false, "run a thunk read from stdin in JSON format")
 	flags.StringVarP(&bumpLock, "bump", "b", "", "re-generate all values in a bass.lock file")
 
 	flags.BoolVarP(&runPrune, "prune", "p", false, "release data and caches retained by runtimes")
@@ -175,6 +177,10 @@ func root(ctx context.Context) error {
 
 	if bumpLock != "" {
 		return cli.WithProgress(ctx, bump)
+	}
+
+	if runRun {
+		return cli.WithProgress(ctx, runThunk)
 	}
 
 	if flags.NArg() == 0 {

--- a/cmd/bass/run_thunk.go
+++ b/cmd/bass/run_thunk.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/vito/bass/pkg/bass"
+	"github.com/vito/bass/pkg/cli"
+	"github.com/vito/progrock"
+)
+
+func runThunk(ctx context.Context) error {
+	return cli.Task(ctx, cmdline, func(ctx context.Context, vtx *progrock.VertexRecorder) error {
+		ctx, runs := bass.TrackRuns(ctx)
+
+		dec := bass.NewRawDecoder(os.Stdin)
+
+		var thunk bass.Thunk
+		if err := dec.Decode(&thunk); err != nil {
+			return err
+		}
+
+		if err := thunk.Run(ctx); err != nil {
+			return err
+		}
+
+		return runs.Wait()
+	})
+}


### PR DESCRIPTION
Symmetrical to `(run)`. Sibling to `bass --export` which takes a thunk (or thunk path) on stdin.