### PR TITLE
disable clearing system env for now

### DIFF
--- a/pkg/bass/env.go
+++ b/pkg/bass/env.go
@@ -5,8 +5,7 @@ import (
 	"strings"
 )
 
-// ImportSystemEnv converts the system env into a scope, clearing the system
-// env in the process. This is a destructive operation.
+// ImportSystemEnv converts the system env into a scope.
 func ImportSystemEnv() *Scope {
 	env := NewEmptyScope()
 
@@ -15,7 +14,9 @@ func ImportSystemEnv() *Scope {
 		env.Set(Symbol(kv[0]), String(kv[1]))
 	}
 
-	os.Clearenv()
+	// TODO: this is breaking docker credential helpers; bring it back once
+	// that's under control (i.e. we stop overloading docker's auth)
+	// os.Clearenv()
 
 	return env
 }


### PR DESCRIPTION
this is breaking docker credential helpers. really we shouldn't be relying on that anyway, but secrets support won't be here til the next release. this isn't really saving anything at the moment anyway since there's no way for a bass script to make arbitrary env access.