### PR TITLE
`(with-env)` is additive, `null` values act as tombstones

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -676,7 +676,7 @@ func init() {
 	Ground.Set("with-env",
 		Func("with-env", "[thunk env]", (Thunk).WithEnv),
 		`returns thunk with env set to the given env`,
-		`=> (with-env ($ jq ".a") {:SECRET "shh"})`)
+		`=> (with-env ($ jq ".a") {:FOO "hello"})`)
 
 	Ground.Set("with-insecure",
 		Func("with-insecure", "[thunk bool]", (Thunk).WithInsecure),

--- a/pkg/bass/thunk.go
+++ b/pkg/bass/thunk.go
@@ -372,9 +372,14 @@ func (thunk Thunk) AppendArgs(args ...Value) Thunk {
 	return thunk
 }
 
-// WithEnv sets the thunk's env.
+// WithEnv sets the thunk's env, replacing any existing values.
 func (thunk Thunk) WithEnv(env *Scope) Thunk {
-	thunk.Env = env
+	if thunk.Env == nil {
+		thunk.Env = env
+	} else {
+		thunk.Env = NewEmptyScope(env, thunk.Env)
+	}
+
 	return thunk
 }
 

--- a/pkg/runtimes/command.go
+++ b/pkg/runtimes/command.go
@@ -89,6 +89,12 @@ func NewCommand(ctx context.Context, starter Starter, thunk bass.Thunk) (Command
 
 	if thunk.Env != nil {
 		err := thunk.Env.Each(func(name bass.Symbol, v bass.Value) error {
+			var null bass.Null
+			if v.Decode(&null) == nil {
+				// env tombstone; skip it
+				return nil
+			}
+
 			val, err := cmd.resolveStr(ctx, v)
 			if err != nil {
 				return fmt.Errorf("resolve env %s: %w", name, err)

--- a/pkg/runtimes/command_test.go
+++ b/pkg/runtimes/command_test.go
@@ -226,6 +226,27 @@ func TestNewCommand(t *testing.T) {
 		})
 	})
 
+	t.Run("nulls in env", func(t *testing.T) {
+		envTombstoneThunk := thunk.WithEnv(
+			bass.Bindings{
+				"FOO": bass.String("hello"),
+				"BAR": bass.String("world"),
+			}.Scope(),
+		).WithEnv(
+			bass.Bindings{
+				"FOO": bass.Null{},
+			}.Scope(),
+		)
+
+		is := is.New(t)
+		cmd, err := runtimes.NewCommand(ctx, starter, envTombstoneThunk)
+		is.NoErr(err)
+		is.Equal(cmd, runtimes.Command{
+			Args: []string{"run"},
+			Env:  []string{"BAR=world"},
+		})
+	})
+
 	t.Run("concatenating", func(t *testing.T) {
 		concatThunk := thunk
 		concatThunk.Args = []bass.Value{


### PR DESCRIPTION
fixes #227 (which has loads more context)