### PR TITLE
use DNS for thunk addresses

### DIFF
--- a/bass/bass.bass
+++ b/bass/bass.bass
@@ -131,7 +131,7 @@
 
   (defn test-buildkit [os arch]
     (-> ($ buildkitd --addr "tcp://0.0.0.0:6107")
-        (with-image (buildkit:image os arch buildkit:test-cni))
+        (with-image (buildkit:image os arch buildkit:test-config))
         (with-mount (cache-dir "bass buildkitd") /var/lib/buildkit/)
         (with-port :grpc 6107)
         insecure!))

--- a/bass/bass.bass
+++ b/bass/bass.bass
@@ -130,7 +130,7 @@
          smoke-tests))
 
   (defn test-buildkit [os arch]
-    (-> ($ buildkitd --addr "tcp://0.0.0.0:6107")
+    (-> ($ dumb-init buildkitd --addr "tcp://0.0.0.0:6107")
         (with-image (buildkit:image os arch buildkit:test-config))
         (with-mount (cache-dir "bass buildkitd") /var/lib/buildkit/)
         (with-port :grpc 6107)

--- a/bass/buildkit-image
+++ b/bass/buildkit-image
@@ -5,4 +5,4 @@
 (defn main []
   (for [{(:os "linux") os
          (:arch "amd64") arch} *stdin*]
-    (emit (buildkit:image os arch buildkit:bass-cni) *stdout*)))
+    (emit (buildkit:image os arch buildkit:bass-config) *stdout*)))

--- a/bass/buildkit.bass
+++ b/bass/buildkit.bass
@@ -2,20 +2,21 @@
 
 (def *buildkit-version* "v0.10.3")
 
-(provide [image bass-cni test-cni]
-  (defn image [os arch cni-path]
-    (let [cni-container-path (/etc/buildkit/ (path-base cni-path))]
-      (from (resolve {:platform {:os os} ; TODO: :arch arch}
-                      ; TODO: move back to upstream once conflist is merged
-                      :repository "vito/buildkit"
-                      :tag (str *buildkit-version* "-conflist")})
-        ($ apk add --no-cache iptables ip6tables)
-        ($ mkdir -p /opt/cni/bin/ /etc/buildkit/)
-        ($ tar -zxf (cni os arch) -C /opt/cni/bin/)
-        ($ cp $cni-path $cni-container-path)
-        ($ cp (mkfile ./buildkitd.toml (buildkitd-toml cni-container-path)) /etc/buildkit/buildkitd.toml))))
+(provide [image bass-config test-config]
+  (use (.git (linux/alpine/git)))
 
-  (defn buildkitd-toml [cni-path]
+  (defn image [os arch config-dir]
+    (from (resolve {:platform {:os os} ; TODO: :arch arch}
+                    ; TODO: move back to upstream once PRs are merged
+                    :repository "vito/buildkit"
+                    :tag (str *buildkit-version* "-conflist-hostname")})
+      ($ apk add --no-cache iptables ip6tables dnsmasq) ; TODO: nix?
+      ($ mkdir -p /opt/cni/bin/ /etc/buildkit/)
+      ($ cp $dnsname /opt/cni/bin/dnsname)
+      ($ tar -zxf (cni os arch) -C /opt/cni/bin/)
+      ($ sh -c "cp $0/* /etc/buildkit/" $config-dir)))
+
+  (defn buildkitd-toml [cni-path dns]
     (str
       "# support insecure! thunks\n"
       "insecure-entitlements = [ \"security.insecure\" ]\n"
@@ -23,11 +24,22 @@
       "# configure bridge networking\n"
       "[worker.oci]\n"
       "networkMode = \"cni\"\n"
-      "cniConfigPath = \"" cni-path "\"\n"
+      "cniConfigPath = \"" (/etc/buildkit/ cni-path) "\"\n"
       "\n"
       "[worker.containerd]\n"
       "networkMode = \"cni\"\n"
-      "cniConfigPath = \"" cni-path "\"\n"))
+      "cniConfigPath = \"" (/etc/buildkit/ cni-path) "\"\n"
+      "\n"
+      "[dns]\n"
+      "nameservers = [\"" dns "\"]\n"))
+
+  (def dnsname
+    (subpath
+      (from (linux/golang)
+        (cd git:github/containers/dnsname/ref/v1.3.1/
+          (-> ($ make binaries)
+              (with-env {:CGO_ENABLED "0"}))))
+      ./bin/dnsname))
 
   (defn cni [os arch]
     (subpath
@@ -41,16 +53,28 @@
       ./cni.tgz))
 
   (defn cni-config [name subnet]
-    {:cniVersion "1.0.0"
+    {:cniVersion "0.4.0"
      :name name
-     :plugins [{:type "bridge"
-                :bridge (str name "0")
-                :isDefaultGateway true
-                :ipMasq true
-                :hairpinMode true
-                :ipam {:type "host-local",
-                       :ranges [[{:subnet subnet}]]}}
-               {:type "firewall"}]})
+     :plugins
+     [{:type "bridge"
+       :bridge (str name "0")
+       :isDefaultGateway true
+       :ipMasq true
+       :hairpinMode true
+       :ipam {:type "host-local",
+              :ranges [[{:subnet subnet}]]}}
+      {:type "firewall"}
+      {:type "dnsname"
+       :domainName "dns.bass"
+       :capabilities {:aliases true}}
+      ]})
 
-  (def bass-cni (mkfile ./bass.conflist (json (cni-config "bass" "10.64.0.0/16"))))
-  (def test-cni (mkfile ./test.conflist (json (cni-config "test" "10.73.0.0/16")))))
+  (def bass-config
+    (mkfs
+      ./bass.conflist (json (cni-config "bass" "10.64.0.0/16"))
+      ./buildkitd.toml (buildkitd-toml ./bass.conflist "10.64.0.1")))
+
+  (def test-config
+    (mkfs
+      ./test.conflist (json (cni-config "bass" "10.73.0.0/16"))
+      ./buildkitd.toml (buildkitd-toml ./test.conflist "10.73.0.1"))))

--- a/bass/buildkit.bass
+++ b/bass/buildkit.bass
@@ -10,7 +10,7 @@
                     ; TODO: move back to upstream once PRs are merged
                     :repository "vito/buildkit"
                     :tag (str *buildkit-version* "-conflist-hostname")})
-      ($ apk add --no-cache iptables ip6tables dnsmasq) ; TODO: nix?
+      ($ apk add --no-cache dumb-init iptables ip6tables dnsmasq) ; TODO: nix?
       ($ mkdir -p /opt/cni/bin/ /etc/buildkit/)
       ($ cp $dnsname /opt/cni/bin/dnsname)
       ($ tar -zxf (cni os arch) -C /opt/cni/bin/)

--- a/bass/buildkit.bass
+++ b/bass/buildkit.bass
@@ -1,15 +1,19 @@
-(def *cni-version* "v1.1.1")
-
+; bumped by hack/bump-buildkit
 (def *buildkit-version* "v0.10.3")
+
+; TODO: move back to upstream once PRs are merged
+(def *buildkit-repository* "vito/buildkit")
+(def *buildkit-variant* "-conflist-hostname")
+
+(def *cni-version* "v1.1.1")
 
 (provide [image bass-config test-config]
   (use (.git (linux/alpine/git)))
 
   (defn image [os arch config-dir]
     (from (resolve {:platform {:os os} ; TODO: :arch arch}
-                    ; TODO: move back to upstream once PRs are merged
-                    :repository "vito/buildkit"
-                    :tag (str *buildkit-version* "-conflist-hostname")})
+                    :repository *buildkit-repository*
+                    :tag (str *buildkit-version* *buildkit-variant*)})
       ($ apk add --no-cache dumb-init iptables ip6tables dnsmasq) ; TODO: nix?
       ($ mkdir -p /opt/cni/bin/ /etc/buildkit/)
       ($ cp $dnsname /opt/cni/bin/dnsname)

--- a/docs/lit/bassics.lit
+++ b/docs/lit/bassics.lit
@@ -267,6 +267,92 @@ that allow it to do a lot with a little.
 }
 
 \section{
+  \title{paths}
+
+  \term{path}{
+    A location of a file or directory within a filesystem.
+  }{
+    Bass distinguishes between file and directory paths by requiring a trailing
+    slash (\code{/}) for directories.
+  }{{{
+    (def file ./some-file)
+    (def dir ./some-dir/)
+    [file dir]
+  }}}{
+    Directory paths can be extended to form longer paths:
+  }{{{
+    dir/sub/file
+  }}}{
+    The above syntax is called path notation. Path notation is technically just
+    reader sugar for nested pairs:
+  }{{{
+    ((dir ./sub/) ./file)
+  }}}
+
+  \term{dir path}{
+    A path to a directory, possibly in a certain context.
+
+    A context-free file path looks like \code{./foo/} - note the presence of a
+    trailing slash.
+
+    When passed to a \t{path root} to form a subpath, the root determines the
+    directory's context.
+  }
+
+  \term{file path}{
+    A path to a file, possibly in a certain context.
+
+    A context-free file path looks like \code{./foo} - note the lack of a
+    trailing slash.
+
+    When passed to a \t{path root} to form a subpath, the root determines the
+    file's context.
+  }
+
+  \term{command path}{
+    A name of a command to be resolved to an actual path to an executable at
+    runtime, using \code{$PATH} or some equivalent.
+  }{{{
+    .cat
+  }}}
+
+  \term{host path}{
+    A file or directory \t{path} relative to a directory on the host
+    machine, called the \italic{context} dir.
+
+    The only way to obtain a host path is through \bass{*dir*}, which is set
+    by Bass when loading a module.
+  }{{{
+    *dir*
+  }}}{
+    Host paths can be passed into \t{thunks} with copy-on-write semantics.
+  }{{{
+    (-> ($ ls $*dir*)
+        (with-image (linux/alpine))
+        run)
+  }}}
+
+  \term{path root}{
+    A \t{combiner} that can be called with a \t{path} argument to return another
+    path. Typically used with path extending notation.
+
+    Any \t{dir path} path is a path root for referencing files or directories
+    beneath the directory.
+  }{{{
+    (def thunk-dir
+      (subpath (.foo) ./dir/))
+
+    (def host-dir
+      *dir*/dir/)
+
+    [thunk-dir/file
+     host-dir/file
+     ./foo/bar/baz
+     ((./foo/ ./bar/) ./baz)]
+  }}}
+}
+
+\section{
   \title{thunks & paths}
 
   \term{thunk}{
@@ -344,26 +430,6 @@ that allow it to do a lot with a little.
     you have an idea I'm all ears!
   }
 
-  \term{path}{
-    A location of a file or directory within a filesystem.
-  }{
-    Bass distinguishes between file and directory paths by requiring a trailing
-    slash (\code{/}) for directories.
-  }{{{
-    (def file ./some-file)
-    (def dir ./some-dir/)
-    [file dir]
-  }}}{
-    Directory paths can be extended to form longer paths:
-  }{{{
-    dir/sub/file
-  }}}{
-    The above syntax is called path notation. Path notation is technically just
-    reader sugar for nested pairs:
-  }{{{
-    ((dir ./sub/) ./file)
-  }}}
-
   \term{thunk path}{
     A file or directory \t{path} relative to the output directory of a
     \t{thunk}.
@@ -395,67 +461,34 @@ that allow it to do a lot with a little.
     (emit touchi/artist *stdout*)
   }}}
 
-  \term{command path}{
-    A name of a command to be resolved to an actual path to an executable at
-    runtime, using \code{$PATH} or some equivalent.
+  \term{thunk addr}{
+    A network address to a port served by a \t{thunk}, i.e. a service.
   }{{{
-    .cat
-  }}}
+    (defn http-server [index]
+      (from (linux/python)
+        (-> ($ python -m http.server)
+            (with-mount (mkfile ./index.html index) ./index.html)
+            (with-port :http 8000))))
 
-  \term{host path}{
-    A file or directory \t{path} relative to a directory on the host
-    machine, called the \italic{context} dir.
-
-    The only way to obtain a host path is through \bass{*dir*}, which is set
-    by Bass when loading a module.
-  }{{{
-    *dir*
+    (addr (http-server "Hello, world!") :http "http://$host:$port")
   }}}{
-    Host paths can be passed into \t{thunks} with copy-on-write semantics.
+    Like thunk paths, thunk addrs can passed to other thunks as first-class
+    values. The \t{runtime} will start the service thunk and wait for its ports
+    to be healthy before running the dependent thunk.
   }{{{
-    (-> ($ ls $*dir*)
-        (with-image (linux/alpine))
-        run)
-  }}}
+    (defn echo [msg]
+      (let [server (http-server msg)]
+        (from (linux/nixery.dev/shell/curl)
+          ($ curl -s (addr server :http "http://$host:$port")))))
 
-  \term{dir path}{
-    A path to a directory, possibly in a certain context.
-
-    A context-free file path looks like \code{./foo/} - note the presence of a
-    trailing slash.
-
-    When passed to a \t{path root} to form a subpath, the root determines the
-    directory's context.
+    (echo "Hello, world!")
+  }}}{
+    When multiple Bass sessions run the same service thunk they will actually
+    be deduplicated into one instance with output multiplexed to all attached
+    clients. The service will only be stopped when all Bass sessions have
+    finished using it. This is all thanks to
+    \link{Buildkit}{https://github.com/moby/buildkit}!
   }
-
-  \term{file path}{
-    A path to a file, possibly in a certain context.
-
-    A context-free file path looks like \code{./foo} - note the lack of a
-    trailing slash.
-
-    When passed to a \t{path root} to form a subpath, the root determines the
-    file's context.
-  }
-
-  \term{path root}{
-    A \t{combiner} that can be called with a \t{path} argument to return another
-    path. Typically used with path extending notation.
-
-    Any \t{dir path} path is a path root for referencing files or directories
-    beneath the directory.
-  }{{{
-    (def thunk-dir
-      (subpath (.foo) ./dir/))
-
-    (def host-dir
-      *dir*/dir/)
-
-    [thunk-dir/file
-     host-dir/file
-     ./foo/bar/baz
-     ((./foo/ ./bar/) ./baz)]
-  }}}
 }
 
 \section{

--- a/docs/lit/index.lit
+++ b/docs/lit/index.lit
@@ -111,6 +111,35 @@ release}{https://github.com/vito/bass/releases/latest} and skim the
     (succeeds? (cargo-test src ./alacritty_terminal/)))
 }}}
 
+\demo-literate{running services}{
+  To run a service thunk, assign names to its ports using \b{with-port}. The
+  provided ports will be healthchecked whenever the service runs.
+}{{{
+  (defn http-server [index]
+    (from (linux/python)
+      (-> ($ python -m http.server)
+          (with-mount (mkfile ./index.html index) ./index.html)
+          (with-port :http 8000))))
+
+  (http-server "Hello, world!")
+}}}{
+  You can use \b{addr} to construct a \t{thunk addr}. A thunk addr is like a
+  \t{thunk path} except it references a named port provided by the thunk rather
+  than a file created by it.
+}{{{
+  (defn echo [msg]
+    (let [server (http-server msg)]
+      (from (linux/nixery.dev/shell/curl)
+        ($ curl -s (addr server :http "http://$host:$port")))))
+
+  (echo "Hello, world!")
+}}}{
+  Like thunks and thunk paths, thunk addrs are just data values. The underlying
+  service thunk only runs when another thunk that needs it runs.
+}{{{
+  (run (echo "Hello, world!"))
+}}}
+
 \demo-literate{building & publishing artifacts}{
   To build from source just run whatever build command you already use.
 }{{{

--- a/hack/bump-buildkit-image
+++ b/hack/bump-buildkit-image
@@ -6,5 +6,5 @@ tag=${1:-dev}
 
 ./bass/buildkit-image -i os=linux -i arch=amd64 | bass --export > /tmp/buildkit-image.tar
 
-skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker-daemon:basslang/buildkit:$tag
-# skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker://basslang/buildkit:$tag
+# skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker-daemon:basslang/buildkit:$tag
+skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker://basslang/buildkit:$tag

--- a/hack/bump-buildkit-image
+++ b/hack/bump-buildkit-image
@@ -6,4 +6,5 @@ tag=${1:-dev}
 
 ./bass/buildkit-image -i os=linux -i arch=amd64 | bass --export > /tmp/buildkit-image.tar
 
-skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker://basslang/buildkit:$tag
+skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker-daemon:basslang/buildkit:$tag
+# skopeo --insecure-policy copy oci-archive:/tmp/buildkit-image.tar docker://basslang/buildkit:$tag

--- a/pkg/bass/fspath.go
+++ b/pkg/bass/fspath.go
@@ -173,20 +173,24 @@ func (value *FSPath) Hash() (string, error) {
 			return err
 		}
 
+		if info.IsDir() {
+			return nil
+		}
+
 		if _, err := idSum.Write([]byte(name + "\x00")); err != nil {
 			return err
 		}
 
 		rc, err := value.FS.Open(name)
 		if err != nil {
-			return err
+			return fmt.Errorf("open %s: %w", name, err)
 		}
 
 		defer rc.Close()
 
 		_, err = io.Copy(idSum, rc)
 		if err != nil {
-			return err
+			return fmt.Errorf("copy: %w", err)
 		}
 
 		return nil

--- a/pkg/bass/fspath_test.go
+++ b/pkg/bass/fspath_test.go
@@ -16,18 +16,41 @@ func TestFSPathEqual(t *testing.T) {
 
 func TestFSPathHash(t *testing.T) {
 	is := is.New(t)
+
 	a, err := NewInMemoryFSDir(
 		FilePath{"top-file"}, String("x"),
 		FilePath{"sub/file"}, String("y"),
 	)
 	is.NoErr(err)
-	b, err := NewInMemoryFSDir(
+	baseHash, err := a.Hash()
+	is.NoErr(err)
+
+	diffContent, err := NewInMemoryFSDir(
 		FilePath{"top-file"}, String("x2"),
 		FilePath{"sub/file"}, String("y2"),
 	)
-	ah, err := a.Hash()
 	is.NoErr(err)
-	bh, err := b.Hash()
+	diffContentHash, err := diffContent.Hash()
 	is.NoErr(err)
-	is.True(ah != bh)
+
+	diffName, err := NewInMemoryFSDir(
+		FilePath{"top-file2"}, String("x"),
+		FilePath{"sub/file2"}, String("y"),
+	)
+	is.NoErr(err)
+	diffNameHash, err := diffName.Hash()
+	is.NoErr(err)
+
+	// distinguish file name from content
+	diffName2, err := NewInMemoryFSDir(
+		FilePath{"top-file"}, String("2x"),
+		FilePath{"sub/file"}, String("2y"),
+	)
+	is.NoErr(err)
+	diffName2Hash, err := diffName2.Hash()
+	is.NoErr(err)
+
+	is.True(baseHash != diffContentHash)
+	is.True(baseHash != diffNameHash)
+	is.True(diffNameHash != diffName2Hash)
 }

--- a/pkg/bass/fspath_test.go
+++ b/pkg/bass/fspath_test.go
@@ -13,3 +13,21 @@ func TestFSPathEqual(t *testing.T) {
 	cp := *a
 	is.True(!a.Equal(&cp))
 }
+
+func TestFSPathHash(t *testing.T) {
+	is := is.New(t)
+	a, err := NewInMemoryFSDir(
+		FilePath{"top-file"}, String("x"),
+		FilePath{"sub/file"}, String("y"),
+	)
+	is.NoErr(err)
+	b, err := NewInMemoryFSDir(
+		FilePath{"top-file"}, String("x2"),
+		FilePath{"sub/file"}, String("y2"),
+	)
+	ah, err := a.Hash()
+	is.NoErr(err)
+	bh, err := b.Hash()
+	is.NoErr(err)
+	is.True(ah != bh)
+}

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -645,13 +645,6 @@ func (b *builder) llb(ctx context.Context, thunk bass.Thunk, extraOpts ...llb.Ru
 		llb.Args([]string{shimExePath, "run", inputFile}),
 	}
 
-	for _, host := range cmd.Hosts {
-		runOpt = append(runOpt, llb.AddExtraHost(
-			host.Host,
-			host.Target,
-		))
-	}
-
 	if thunk.Insecure {
 		needsInsecure = true
 

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -1,14 +1,12 @@
 package runtimes
 
 import (
-	"bufio"
 	"context"
 	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/fs"
-	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -194,7 +192,7 @@ func (runtime *Buildkit) Resolve(ctx context.Context, imageRef bass.ImageRef) (b
 			Platform: &runtime.Platform,
 		})
 		if err != nil {
-			return nil, fmt.Errorf("resolve: %w", err)
+			return nil, err
 		}
 
 		imageRef.Digest = digest.String()
@@ -230,15 +228,11 @@ func (runtime *Buildkit) Run(ctx context.Context, thunk bass.Thunk) error {
 func (runtime *Buildkit) Start(ctx context.Context, thunk bass.Thunk) (StartResult, error) {
 	ctx, stop := context.WithCancel(ctx)
 
-	discovery := runtime.newDiscovery(ctx, thunk.Ports)
+	host := thunk.Name()
 
-	discovery.Start()
+	health := runtime.newHealth(ctx, host, thunk.Ports)
 
-	pingAddr, err := discovery.Addr()
-	if err != nil {
-		stop()
-		return StartResult{}, fmt.Errorf("get discovery addr: %w", err)
-	}
+	health.Start()
 
 	runs := bass.RunsFromContext(ctx)
 
@@ -252,27 +246,13 @@ func (runtime *Buildkit) Start(ctx context.Context, thunk bass.Thunk) (StartResu
 			},
 			nil,             // exports
 			llb.IgnoreCache, // never cache services
-			llb.AddEnv("_BASS_PING", pingAddr),
 		)
 		return nil // disregard err; services don't have to exit cleanly
 	})
 
 	result := StartResult{
 		Ports: PortInfos{},
-		Hosts: []CommandHost{},
 	}
-
-	ip, err := discovery.ContainerIP()
-	if err != nil {
-		return result, fmt.Errorf("get container IP: %w", err)
-	}
-
-	host := thunk.Name()
-
-	result.Hosts = append(result.Hosts, CommandHost{
-		Host:   host,
-		Target: ip,
-	})
 
 	for _, port := range thunk.Ports {
 		result.Ports[port.Name] = bass.Bindings{
@@ -281,7 +261,7 @@ func (runtime *Buildkit) Start(ctx context.Context, thunk bass.Thunk) (StartResu
 		}.Scope()
 	}
 
-	err = discovery.Wait()
+	err := health.Wait()
 	if err != nil {
 		return StartResult{}, err
 	}
@@ -512,36 +492,28 @@ func result(ctx context.Context, gw gwclient.Client, st marshalable) (*gwclient.
 	})
 }
 
-type ipDiscovery struct {
+type portHealthChecker struct {
 	runtime *Buildkit
 	eg      *errgroup.Group
 	ctx     context.Context
 
+	host  string
 	ports []bass.ThunkPort
-
-	serverAddr    string
-	hasServerAddr chan struct{}
-
-	containerIP    string
-	hasContainerIP chan struct{}
 }
 
-func (runtime *Buildkit) newDiscovery(ctx context.Context, ports []bass.ThunkPort) *ipDiscovery {
+func (runtime *Buildkit) newHealth(ctx context.Context, host string, ports []bass.ThunkPort) *portHealthChecker {
 	eg, ctx := errgroup.WithContext(ctx)
-	return &ipDiscovery{
+	return &portHealthChecker{
 		runtime: runtime,
 		eg:      eg,
 		ctx:     ctx,
 
+		host:  host,
 		ports: ports,
-
-		hasServerAddr: make(chan struct{}),
-
-		hasContainerIP: make(chan struct{}),
 	}
 }
 
-func (d *ipDiscovery) Start() {
+func (d *portHealthChecker) Start() {
 	d.eg.Go(func() error {
 		_, err := d.runtime.Client.Build(d.ctx, kitdclient.SolveOpt{
 			Session: []session.Attachable{
@@ -552,34 +524,11 @@ func (d *ipDiscovery) Start() {
 	})
 }
 
-func (d *ipDiscovery) Addr() (string, error) {
-	select {
-	case <-d.hasServerAddr:
-		return d.serverAddr, nil
-	case <-d.ctx.Done():
-		return "", d.ctx.Err()
-	}
-}
-
-func (d *ipDiscovery) ContainerIP() (net.IP, error) {
-	select {
-	case <-d.hasContainerIP:
-		ip := net.ParseIP(d.containerIP)
-		if ip == nil {
-			return nil, fmt.Errorf("invalid IP: %s", d.containerIP)
-		}
-
-		return ip, nil
-	case <-d.ctx.Done():
-		return nil, d.ctx.Err()
-	}
-}
-
-func (d *ipDiscovery) Wait() error {
+func (d *portHealthChecker) Wait() error {
 	return d.eg.Wait()
 }
 
-func (d *ipDiscovery) doBuild(ctx context.Context, gw gwclient.Client) (*gwclient.Result, error) {
+func (d *portHealthChecker) doBuild(ctx context.Context, gw gwclient.Client) (*gwclient.Result, error) {
 	shimExe, err := d.runtime.shim()
 	if err != nil {
 		return nil, err
@@ -616,41 +565,20 @@ func (d *ipDiscovery) doBuild(ctx context.Context, gw gwclient.Client) (*gwclien
 
 	defer container.Release(ctx)
 
-	srvR, srvW := io.Pipe()
-
-	args := []string{shimExePath, "discover"}
+	args := []string{shimExePath, "check", d.host + ".dns.bass"}
 	for _, port := range d.ports {
 		args = append(args, fmt.Sprintf("%s:%d", port.Name, port.Port))
 	}
 
 	proc, err := container.Start(ctx, gwclient.StartRequest{
 		Args:   args,
-		Stdout: srvW,
 		Stderr: nopCloser{ioctx.StderrFromContext(ctx)},
 	})
 	if err != nil {
 		return nil, err
 	}
 
-	scan := bufio.NewScanner(srvR)
-	d.eg.Go(func() error {
-		// server prints its own address so it can be passed to the thunk's shim
-		if scan.Scan() {
-			d.serverAddr = scan.Text()
-			close(d.hasServerAddr)
-		}
-
-		// server prints the container IP received from the thunk's shim
-		if scan.Scan() {
-			d.containerIP = scan.Text()
-			close(d.hasContainerIP)
-		}
-
-		return scan.Err()
-	})
-
 	err = proc.Wait()
-	srvW.CloseWithError(err)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/runtimes/command.go
+++ b/pkg/runtimes/command.go
@@ -26,7 +26,6 @@ type Command struct {
 	// these don't need to be marshaled, since they're part of the container
 	// setup and not passed to the shim
 	Mounts []CommandMount `json:"-"`
-	Hosts  []CommandHost  `json:"-"`
 
 	mounted map[string]bool
 	starter Starter

--- a/pkg/runtimes/command.go
+++ b/pkg/runtimes/command.go
@@ -51,12 +51,6 @@ type Starter interface {
 type StartResult struct {
 	// A mapping from each port to its address info (host, port, etc.)
 	Ports PortInfos
-
-	// Hostname to IP mappings to configure on the container
-	//
-	// Order must be deterministic, hence this is not a map. There may be
-	// duplicates.
-	Hosts []CommandHost
 }
 
 type PortInfos map[string]*bass.Scope
@@ -371,8 +365,6 @@ func (cmd *Command) resolveValue(ctx context.Context, val bass.Value, dest any) 
 		if err != nil {
 			return err
 		}
-
-		cmd.Hosts = append(cmd.Hosts, result.Hosts...)
 
 		return bass.String(str).Decode(dest)
 	}

--- a/pkg/runtimes/command_test.go
+++ b/pkg/runtimes/command_test.go
@@ -2,7 +2,6 @@ package runtimes_test
 
 import (
 	"context"
-	"net"
 	"testing"
 
 	"github.com/vito/bass/pkg/bass"
@@ -375,9 +374,6 @@ func TestNewCommand(t *testing.T) {
 						"port": bass.Int(6455),
 					}.Scope(),
 				},
-				Hosts: []runtimes.CommandHost{
-					{"carey", net.IPv4(127, 0, 0, 1)},
-				},
 			},
 		}
 
@@ -386,9 +382,6 @@ func TestNewCommand(t *testing.T) {
 		is.NoErr(err)
 		is.Equal(cmd, runtimes.Command{
 			Args: []string{"run", "some://drew:6455/addr"},
-			Hosts: []runtimes.CommandHost{
-				{"carey", net.IPv4(127, 0, 0, 1)},
-			},
 		})
 
 		is.Equal(starter.Started, svcThunk)
@@ -410,9 +403,6 @@ func TestNewCommand(t *testing.T) {
 						"host": bass.String("drew"),
 						"port": bass.Int(6455),
 					}.Scope(),
-				},
-				Hosts: []runtimes.CommandHost{
-					{"carey", net.IPv4(127, 0, 0, 1)},
 				},
 			},
 		}
@@ -439,9 +429,6 @@ func TestNewCommand(t *testing.T) {
 						"port": bass.Int(6455),
 					}.Scope(),
 				},
-				Hosts: []runtimes.CommandHost{
-					{"carey", net.IPv4(127, 0, 0, 1)},
-				},
 			},
 		}
 
@@ -451,9 +438,6 @@ func TestNewCommand(t *testing.T) {
 		is.Equal(cmd, runtimes.Command{
 			Args: []string{"run"},
 			Env:  []string{"ADDR=some://drew:6455/addr"},
-			Hosts: []runtimes.CommandHost{
-				{"carey", net.IPv4(127, 0, 0, 1)},
-			},
 		})
 
 		is.Equal(starter.Started, svcThunk)

--- a/pkg/runtimes/util/buildkitd/buildkitd.go
+++ b/pkg/runtimes/util/buildkitd/buildkitd.go
@@ -197,6 +197,7 @@ func installBuildkit(ctx context.Context) error {
 		"--name", containerName,
 		"--privileged",
 		image+":"+Version,
+		"dumb-init",
 		"buildkitd",
 		"--debug",
 	)


### PR DESCRIPTION
Thunks now use DNS to reach each other instead of IPs.

IP addresses are random; using DNS gives us a stable value instead: the thunk hash (e.g. `GRLO5DSIPLJPQ`). This way your caches won't be busted every time you run a service.

Depends on https://github.com/moby/buildkit/pull/3044 and points to my fork of the `moby/buildkit` image for now: `vito/buildkit:v0.10.3-conflist-hostname`.