### PR TITLE
bump ubuntu vm in lima config

### DIFF
--- a/lima/bass.yaml
+++ b/lima/bass.yaml
@@ -1,7 +1,7 @@
 images:
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-amd64.img"
+- location: "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img"
   arch: "x86_64"
-- location: "https://cloud-images.ubuntu.com/impish/current/impish-server-cloudimg-arm64.img"
+- location: "https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-arm64.img"
   arch: "aarch64"
 
 # CPUs: if you see performance issues, try limiting cpus to 1.


### PR DESCRIPTION
fixes errors because impish url is no longer available / moved #232