### PR TITLE
fix link to base16 project in "thanks"

### DIFF
--- a/docs/lit/meta/thanks.lit
+++ b/docs/lit/meta/thanks.lit
@@ -15,7 +15,7 @@
   powers the default runtime and really drives all the magic behind
   running and composing thunks.
 }{
-  The \link{base16 project}{http://chriskempson.com/projects/base16/} is the
+  The \link{base16 project}{https://github.com/chriskempson/base16} is the
   source for all of the color schemes. Thanks to the OGs who developed all
   these awesome color schemes, and Chris Kempson for starting the base16
   project - it's super convenient!


### PR DESCRIPTION
At time of this commit, http://chriskempson.com/projects/base16/ redirects to https://plinko.site, which does not seem likely to be the intention.