### PR TITLE
duplicate concat as a replacement for append

### DIFF
--- a/bass/shipit
+++ b/bass/shipit
@@ -59,7 +59,7 @@
   (let [bins (all-bins src tag)
         archives (vals bins)
         repros (reduce-kv (fn [acc k v] (cons (archive-repro k v) acc)) [] bins)
-        files (append archives repros)
+        files (concat archives repros)
         sums (mkfile ./sha256sums.txt (sha256sums src files))]
     (bass:smoke-test bins:linux-amd64)
     (conj files sums)))

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -2009,6 +2009,18 @@ func TestGroundList(t *testing.T) {
 			),
 		},
 		{
+			Name: "concat",
+			Bass: "(concat [1 2] [3 4 5] [6])",
+			Result: bass.NewList(
+				bass.Int(1),
+				bass.Int(2),
+				bass.Int(3),
+				bass.Int(4),
+				bass.Int(5),
+				bass.Int(6),
+			),
+		},
+		{
 			Name: "filter",
 			Bass: "(filter symbol? [1 :two 3 :four 5 :six])",
 			Result: bass.NewList(

--- a/std/root.bass
+++ b/std/root.bass
@@ -214,23 +214,38 @@
     [] z
     [x & xs'] (foldl f (f z x) xs')))
 
-(provide (append)
-  (defn append1 [xs ys]
+; TODO add a deprecation warning
+; TODO replace implementation with concat?
+ (provide (append) 
+   (defn append1 [xs ys] 
+     (case xs 
+       [] ys 
+       [x & xs'] (cons x (append1 xs' ys)))) 
+  
+   ; joins all given lists into one list 
+   ; DEPRECATED by concat, to be removed in v1.0.0
+   ; 
+   ; => (append [1] [2 3] [4 5 6]) 
+   (defn append xss 
+     (foldl append1 [] xss))) 
+
+(provide (concat)
+  (defn concat1 [xs ys]
     (case xs
       [] ys
-      [x & xs'] (cons x (append1 xs' ys))))
+      [x & xs'] (cons x (concat1 xs' ys))))
 
   ; joins all given lists into one list
   ;
-  ; => (append [1] [2 3] [4 5 6])
-  (defn append xss
-    (foldl append1 [] xss)))
+  ; => (concat [1] [2 3] [4 5 6])
+  (defn concat xss
+    (foldl concat1 [] xss)))
 
 ; returns only values from xs which satisfy the predicate
 ;
 ; => (filter symbol? [:abc 123 :def "456"])
 (defn filter [predicate xs]
-  (apply append (map (fn [x] (if (predicate x) [x] [])) xs)))
+  (apply concat (map (fn [x] (if (predicate x) [x] [])) xs)))
 
 ; conjoins values onto the end of a list
 ;

--- a/std/root.bass
+++ b/std/root.bass
@@ -229,9 +229,6 @@
 ^{:deprecated "Use (concat) instead."}
 (def append concat)
 
-(meta append)
-; => {:doc "concatenates things" :file <fs>/history :line 1 :column 0 :deprecated "Use (concat) instead."}
-
 ; returns only values from xs which satisfy the predicate
 ;
 ; => (filter symbol? [:abc 123 :def "456"])

--- a/std/root.bass
+++ b/std/root.bass
@@ -214,21 +214,6 @@
     [] z
     [x & xs'] (foldl f (f z x) xs')))
 
-; TODO add a deprecation warning
-; TODO replace implementation with concat?
- (provide (append) 
-   (defn append1 [xs ys] 
-     (case xs 
-       [] ys 
-       [x & xs'] (cons x (append1 xs' ys)))) 
-  
-   ; joins all given lists into one list 
-   ; DEPRECATED by concat, to be removed in v1.0.0
-   ; 
-   ; => (append [1] [2 3] [4 5 6]) 
-   (defn append xss 
-     (foldl append1 [] xss))) 
-
 (provide (concat)
   (defn concat1 [xs ys]
     (case xs
@@ -240,6 +225,12 @@
   ; => (concat [1] [2 3] [4 5 6])
   (defn concat xss
     (foldl concat1 [] xss)))
+
+^{:deprecated "Use (concat) instead."}
+(def append concat)
+
+(meta append)
+; => {:doc "concatenates things" :file <fs>/history :line 1 :column 0 :deprecated "Use (concat) instead."}
 
 ; returns only values from xs which satisfy the predicate
 ;

--- a/std/run.bass
+++ b/std/run.bass
@@ -67,7 +67,7 @@
 (defn wrap-cmd [thunk cmd & args]
   (-> thunk
       (with-cmd cmd)
-      (with-args (append args (cons (thunk-cmd thunk)
+      (with-args (concat args (cons (thunk-cmd thunk)
                                     (thunk-args thunk))))))
 
 (provide [linux]


### PR DESCRIPTION
Draft for #114, started with a naive approach, duplicate `(append)` and rename it `(concat)`. Then Replaced uses of append with concat and duplicated go test of append for concat.

- [x] Implement `(concat)` based on 
- [x] Replace uses of `(append)` with `(concat)`
- [x] Update tests
- [ ] Add in code deprecation warning
- [x] Double check uses of append in existing scripts

So far so good. In terms of deprecation imaging the following points need to be handled:
- Is there a way `(append)` can print a warning? does that even make sense? (ideally it would do so once per program execution not per function execution).
- Should `(append)` be updated to use `(concat)`'s implementation, or is it better to keep it as a duplicate because it's short.

Bare with me I'm still brushing up on my LISP, but feel free to let me know if something is obviously wrong.