### PR TITLE
don't ignore caches for services

### DIFF
--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -262,8 +262,7 @@ func (runtime *Buildkit) Start(ctx context.Context, thunk bass.Thunk) (StartResu
 			func(st llb.ExecState, _ string) marshalable {
 				return st.GetMount(ioDir)
 			},
-			nil,             // exports
-			llb.IgnoreCache, // never cache services
+			nil, // exports
 		)
 
 		return nil
@@ -773,7 +772,7 @@ func (b *builder) llb(ctx context.Context, thunk bass.Thunk, extraOpts ...llb.Ru
 		}
 	}
 
-	if len(thunk.Ports) > 0 || b.runtime.Config.DisableCache {
+	if b.runtime.Config.DisableCache {
 		runOpt = append(runOpt, llb.IgnoreCache)
 	}
 


### PR DESCRIPTION
the intention here was to prevent accidentally caching a service that exits 0 when interrupted.

in reality this also prevented explicit cache mounts from working; they'd always just be empty. cache mounts are required for services that keep state, e.g. Nixery.

we also don't want to introduce any randomness to the LLB since that would prevent sharing of resources.

it doesn't seem possible to meet all of these constraints at the moment, so just get rid of the cache prevention as I haven't seen it actually cause any problems yet. maybe because we always interrupt the service, and that prevents buildkit from caching even if it exits 0? or maybe everything is just exiting nonzero properly? (none of this is confirmed, but it would be nice!)