### PR TITLE
add `:lines` protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ To parse values from a thunk's `stdout` or from a thunk path, use
 ```clojure
 => (next (read (from (linux/alpine) ($ head "-1" thunk/some-file)) :raw))
 "# bass\n"
+=> (next (read thunk/some-file :lines))
+"# bass"
 => (next (read thunk/some-file :unix-table))
 ("#" "bass")
 ```

--- a/demos/booklit/test-last-10.bass
+++ b/demos/booklit/test-last-10.bass
@@ -5,11 +5,10 @@
 (defn main testflags
   (let [latest git:github/vito/booklit/ref/HEAD/
         booklit (load (latest/bass/booklit.bass))
-        commits (read (from (linux/alpine/git)
-                        (cd latest
-                          ($ git rev-list "HEAD~10..HEAD")))
-                      :unix-table)]
-    (for [[sha] commits]
+        commits (from (linux/alpine/git)
+                  (cd latest
+                    ($ git rev-list "HEAD~10..HEAD")))]
+    (for [sha (read commits :lines)]
       (let [src (git:github/vito/booklit/sha/ (string->dir sha))
             ok? (succeeds? (booklit:tests src testflags))]
         (log (if ok? "passed" "failed") :sha sha)))))

--- a/docs/lit/guide.lit
+++ b/docs/lit/guide.lit
@@ -81,7 +81,8 @@ for common tasks. If you'd like to learn the language, see \reference{bassics}.
     \title{reading output}
 
     \bass-literate{
-      To parse a stream of JSON values from a thunk's \code{stdout}, call \b{read}:
+      To parse a stream of JSON values from a thunk's \code{stdout}, call
+      \b{read} with the \bass{:json} protocol:
     }{{{
       (def cat-thunk
         (from (linux/alpine)
@@ -92,6 +93,13 @@ for common tasks. If you'd like to learn the language, see \reference{bassics}.
         [(next stream :end)
          (next stream :end)
          (next stream :end)])
+    }}}{
+      To read output line-by-line, set the protocol to \bass{:lines}:
+    }{{{
+      (-> ($ ls -r /usr/bin)
+          (with-image (linux/alpine))
+          (read :lines)
+          next)
     }}}{
       To parse UNIX style tabular output, set the protocol to \bass{:unix-table}:
     }{{{

--- a/docs/lit/index.lit
+++ b/docs/lit/index.lit
@@ -235,7 +235,7 @@ release}{https://github.com/vito/bass/releases/latest} and skim the
 
   (-> (from wget
         ($ wget --version))
-      (read :unix-table)
+      (read :lines)
       next)
 }}}{
   \link{Nix}{https://nixos.org} fans are probably seething right now. This
@@ -262,7 +262,7 @@ release}{https://github.com/vito/bass/releases/latest} and skim the
 
   (-> (from image
         ($ wget --version))
-      (read :unix-table)
+      (read :lines)
       next)
 }}}{
   Bass does everything it can to support \t{hermetic} thunks, but it stops

--- a/pkg/bass/protocol_test.go
+++ b/pkg/bass/protocol_test.go
@@ -1,0 +1,69 @@
+package bass_test
+
+import (
+	"testing"
+
+	"github.com/vito/bass/pkg/bass"
+)
+
+func TestProtocols(t *testing.T) {
+	for _, e := range []BasicExample{
+		{
+			Name: "raw",
+			Bass: `(take-all (read (mkfile ./foo "hello\nworld\n") :raw))`,
+			Result: bass.NewList(
+				bass.String("hello\nworld\n"),
+			),
+		},
+		{
+			Name:   "lines",
+			Bass:   `(take-all (read (mkfile ./foo "hello\nworld\n") :lines))`,
+			Result: bass.NewList(bass.String("hello"), bass.String("world")),
+		},
+		{
+			Name:   "lines includes blank lines",
+			Bass:   `(take-all (read (mkfile ./foo "hello\n\nworld\n") :lines))`,
+			Result: bass.NewList(bass.String("hello"), bass.String(""), bass.String("world")),
+		},
+		{
+			Name:   "lines includes last unterminated line",
+			Bass:   `(take-all (read (mkfile ./foo "hello\nworld") :lines))`,
+			Result: bass.NewList(bass.String("hello"), bass.String("world")),
+		},
+		{
+			Name: "unix-table",
+			Bass: `(take-all (read (mkfile ./foo "hello world\ngoodbye universe\n") :unix-table))`,
+			Result: bass.NewList(
+				bass.NewList(bass.String("hello"), bass.String("world")),
+				bass.NewList(bass.String("goodbye"), bass.String("universe")),
+			),
+		},
+		{
+			Name: "unix-table includes empty rows",
+			Bass: `(take-all (read (mkfile ./foo "hello world\n\ngoodbye universe\n") :unix-table))`,
+			Result: bass.NewList(
+				bass.NewList(bass.String("hello"), bass.String("world")),
+				bass.NewList(),
+				bass.NewList(bass.String("goodbye"), bass.String("universe")),
+			),
+		},
+		{
+			Name: "unix-table includes last unterminated row",
+			Bass: `(take-all (read (mkfile ./foo "hello world\ngoodbye universe") :unix-table))`,
+			Result: bass.NewList(
+				bass.NewList(bass.String("hello"), bass.String("world")),
+				bass.NewList(bass.String("goodbye"), bass.String("universe")),
+			),
+		},
+		{
+			Name: "json",
+			Bass: `(take-all (read (mkfile ./foo "{\"a\":1}{\"b\":\"two\"}") :json))`,
+			Result: bass.NewList(
+				bass.Bindings{"a": bass.Int(1)}.Scope(),
+				bass.Bindings{"b": bass.String("two")}.Scope(),
+			),
+		},
+	} {
+		e.Run(t)
+	}
+}

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -180,7 +180,7 @@ func Suite(t *testing.T, pool bass.RuntimePool) {
 		},
 		{
 			File:   "oci-archive-image.bass",
-			Result: bass.NewList(bass.String("Hello"), bass.String("from"), bass.String("Docker!")),
+			Result: bass.String("Hello from Docker!"),
 		},
 		{
 			File:   "remount-workdir.bass",

--- a/pkg/runtimes/testdata/oci-archive-image.bass
+++ b/pkg/runtimes/testdata/oci-archive-image.bass
@@ -13,7 +13,7 @@
    :tag "latest"})
 
 (def hello-content
-  (read (from hello-image ($ /hello)) :unix-table))
+  (read (from hello-image ($ /hello)) :lines))
 
 ; first line is blank
 (next hello-content)

--- a/pkg/runtimes/testdata/secrets.bass
+++ b/pkg/runtimes/testdata/secrets.bass
@@ -23,9 +23,9 @@
 
 (def result
   {:results [(-> stdin-secret (read :json) next)
-             (-> env-secret (read :unix-table) next first)
-             (-> arg-secret (read :unix-table) next first)
-             (-> file-secret (read :unix-table) next first)]
+             (-> env-secret (read :lines) next)
+             (-> arg-secret (read :lines) next)
+             (-> file-secret (read :lines) next)]
    :thunks [stdin-secret env-secret arg-secret file-secret]})
 
 (emit result:thunks *stdout*)


### PR DESCRIPTION
fixes #240 

usage:

```clojure
(take-all (read (mkfile ./foo "a\nb\nc") :lines))
; ("a" "b" "c")
```