### PR TITLE
pkg/bass/ground.go: add quotes around godoc arguments

### DIFF
--- a/pkg/bass/ground.go
+++ b/pkg/bass/ground.go
@@ -694,12 +694,12 @@ func init() {
 	Ground.Set("with-port",
 		Func("with-port", "[thunk sym int]", (Thunk).WithPort),
 		`returns thunk with a named port appended to its ports`,
-		`=> (with-port ($ godoc -http=:6060) :godoc 6060)`)
+		`=> (with-port ($ godoc "-http=:6060") :godoc 6060)`)
 
 	Ground.Set("with-tls",
 		Func("with-tls", "[thunk cert-path key-path]", (Thunk).WithTLS),
 		`returns thunk with paths to a TLS certificate and key to generate`,
-		`=> (with-tls ($ godoc -http=:6060) ./cert.pem ./key.pem)`)
+		`=> (with-tls ($ godoc "-http=:6060") ./cert.pem ./key.pem)`)
 
 	Ground.Set("with-mount",
 		Func("with-mount", "[thunk source target]", (Thunk).WithMount),


### PR DESCRIPTION
Fixes #251.

ℹ️ I've not tried to check that this works locally. Or rather, I've tried the actual call in the REPL, but I haven't tried building the docs.