### PR TITLE
fix: runner url in contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ You'll need to start your own runner for your PR checks to be able to run:
 
 ```sh
 echo '[github.bass-lang.org]:6455 ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBHWy9mZd5afRbKuXUQs7g/30bl+F8wzlU66xTYknGMfpkOm2YQXRTPVTUs5/K3nIdPGFP4b7QOSCOahXVqA98Ec=' >> ~/.ssh/known_hosts
-bass --runner myghuser@github.bass-loop.org
+bass --runner myghuser@github.bass-lang.org
 ```
 
 *This runner is only ever used by actions you initiate. It is safe to leave


### PR DESCRIPTION
I had this strange error trying to run the runner for a PR:
```
15:56:33.469	error	failed to connect	{"error": "dial tcp: lookup github.bass-loop.org on ....1:53: no such host"}
dial: 1 error occurred:
	* dial tcp: lookup github.bass-loop.org on ...1:53: no such host
```
Looks like the url wasn't correct in the example.