### PR TITLE
introduce Custodians, refactor `(read)`, add `(assert)`

### DIFF
--- a/pkg/bass/custodian.go
+++ b/pkg/bass/custodian.go
@@ -1,0 +1,56 @@
+package bass
+
+import (
+	"context"
+	"io"
+
+	"github.com/hashicorp/go-multierror"
+)
+
+type Custodian struct {
+	closers []io.Closer
+}
+
+type custodianKey struct{}
+
+func NewCustodian() *Custodian {
+	return &Custodian{}
+}
+
+func WithCustodian(ctx context.Context, custodian *Custodian) context.Context {
+	return context.WithValue(ctx, custodianKey{}, custodian)
+}
+
+func ForkCustodian(ctx context.Context) context.Context {
+	child := NewCustodian()
+
+	if parent, ok := CustodianFrom(ctx); ok {
+		parent.AddCloser(child)
+	}
+
+	return context.WithValue(ctx, custodianKey{}, child)
+}
+
+func CustodianFrom(ctx context.Context) (*Custodian, bool) {
+	custodian := ctx.Value(custodianKey{})
+	if custodian != nil {
+		return custodian.(*Custodian), true
+	}
+
+	return nil, false
+}
+
+func (c *Custodian) AddCloser(closer io.Closer) {
+	c.closers = append(c.closers, closer)
+}
+
+func (c *Custodian) Close() error {
+	var errs error
+	for _, closer := range c.closers {
+		if err := closer.Close(); err != nil {
+			errs = multierror.Append(errs, err)
+		}
+	}
+
+	return errs
+}

--- a/pkg/bass/filesystem_path.go
+++ b/pkg/bass/filesystem_path.go
@@ -42,17 +42,27 @@ func ParseFileOrDirPath(arg string) FileOrDirPath {
 
 	var fod FileOrDirPath
 	if isDir {
-		fod.Dir = &DirPath{
-			// trim suffix left behind from Clean returning "/"
-			Path: strings.TrimSuffix(path.Clean(p), "/"),
-		}
+		dir := NewDirPath(p)
+		fod.Dir = &dir
 	} else {
-		fod.File = &FilePath{
-			Path: path.Clean(p),
-		}
+		file := NewFilePath(p)
+		fod.File = &file
 	}
 
 	return fod
+}
+
+func NewFilePath(p string) FilePath {
+	return FilePath{
+		Path: path.Clean(p),
+	}
+}
+
+func NewDirPath(p string) DirPath {
+	return DirPath{
+		// trim suffix left behind from Clean returning "/"
+		Path: strings.TrimSuffix(path.Clean(p), "/"),
+	}
 }
 
 func IsPathLike(arg string) bool {

--- a/pkg/bass/ground_test.go
+++ b/pkg/bass/ground_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -16,7 +17,6 @@ import (
 	"github.com/mattn/go-colorable"
 	"github.com/vito/bass/pkg/bass"
 	"github.com/vito/bass/pkg/basstest"
-	. "github.com/vito/bass/pkg/basstest"
 	"github.com/vito/bass/pkg/ioctx"
 	"github.com/vito/bass/pkg/zapctx"
 	"github.com/vito/is"
@@ -429,7 +429,7 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 				t.Run(fmt.Sprintf("%v", arg), func(t *testing.T) {
 					is := is.New(t)
 
-					res, err := Eval(scope, bass.Pair{
+					res, err := basstest.Eval(scope, bass.Pair{
 						A: bass.Symbol(test.Name),
 						D: bass.NewList(Const{arg}),
 					})
@@ -442,12 +442,12 @@ func TestGroundPrimitivePredicates(t *testing.T) {
 				t.Run(fmt.Sprintf("%v", arg), func(t *testing.T) {
 					is := is.New(t)
 
-					res, err := Eval(scope, bass.Pair{
+					res, err := basstest.Eval(scope, bass.Pair{
 						A: bass.Symbol(test.Name),
 						D: bass.NewList(Const{arg}),
 					})
 					is.NoErr(err)
-					Equal(t, res, bass.Bool(false))
+					basstest.Equal(t, res, bass.Bool(false))
 				})
 			}
 		})
@@ -955,7 +955,7 @@ func TestGroundScope(t *testing.T) {
 				is.True(strings.Contains(err.Error(), test.ErrContains))
 			} else {
 				is.NoErr(err)
-				Equal(t, res, test.Result)
+				basstest.Equal(t, res, test.Result)
 
 				if test.Bindings != nil {
 					is.Equal(scope.Bindings, test.Bindings)
@@ -972,7 +972,7 @@ func TestGroundScope(t *testing.T) {
 
 		res, err := bass.EvalFSFile(context.Background(), scope, bass.NewInMemoryFile("test", "(current-scope)"))
 		is.NoErr(err)
-		Equal(t, res, scope)
+		basstest.Equal(t, res, scope)
 
 		res, err = bass.EvalFSFile(context.Background(), scope, bass.NewInMemoryFile("test", "(make-scope)"))
 		is.NoErr(err)
@@ -1272,7 +1272,7 @@ func TestGroundBoolean(t *testing.T) {
 				is.True(strings.Contains(err.Error(), test.ErrContains))
 			} else {
 				is.NoErr(err)
-				Equal(t, res, test.Result)
+				basstest.Equal(t, res, test.Result)
 
 				if test.Bindings != nil {
 					is.Equal(scope.Bindings, test.Bindings)
@@ -1485,7 +1485,7 @@ func TestGroundStdlib(t *testing.T) {
 				is.True(strings.Contains(err.Error(), test.ErrContains))
 			} else {
 				is.NoErr(err)
-				Equal(t, res, test.Result)
+				basstest.Equal(t, res, test.Result)
 
 				if test.Bindings != nil {
 					is.Equal(scope.Bindings, test.Bindings)
@@ -1603,7 +1603,7 @@ func TestGroundPipes(t *testing.T) {
 				is.NoErr(err)
 			}
 
-			scope.Set("source", &bass.Source{bass.NewJSONSource("test", sourceBuf)})
+			scope.Set("source", &bass.Source{bass.NewJSONSource("test", io.NopCloser(sourceBuf))})
 
 			reader := bass.NewInMemoryFile("test", test.Bass)
 			res, err := bass.EvalFSFile(context.Background(), scope, reader)
@@ -1611,15 +1611,15 @@ func TestGroundPipes(t *testing.T) {
 				is.True(errors.Is(err, test.Err))
 			} else {
 				is.NoErr(err)
-				Equal(t, res, test.Result)
+				basstest.Equal(t, res, test.Result)
 			}
 
-			stdoutSource := bass.NewJSONSource("test", sinkBuf)
+			stdoutSource := bass.NewJSONSource("test", io.NopCloser(sinkBuf))
 
 			for _, val := range test.Sink {
 				next, err := stdoutSource.Next(context.Background())
 				is.NoErr(err)
-				Equal(t, next, val)
+				basstest.Equal(t, next, val)
 			}
 		})
 	}

--- a/pkg/bass/memfs.go
+++ b/pkg/bass/memfs.go
@@ -46,8 +46,5 @@ func NewInMemoryFile(name string, content string) *FSPath {
 	_ = mfs.MkdirAll(path.Dir(name), 0755)
 	_ = mfs.WriteFile(name, []byte(content), 0644)
 
-	return &FSPath{
-		FS:   mfs,
-		Path: ParseFileOrDirPath(name),
-	}
+	return NewFSPath(mfs, ParseFileOrDirPath(name))
 }

--- a/pkg/bass/pipes.go
+++ b/pkg/bass/pipes.go
@@ -13,6 +13,7 @@ import (
 type PipeSource interface {
 	String() string
 	Next(context.Context) (Value, error)
+	Close() error
 }
 
 type PipeSink interface {
@@ -120,19 +121,27 @@ func (src *InMemorySource) Next(_ context.Context) (Value, error) {
 	return val, nil
 }
 
+func (src *InMemorySource) Close() error {
+	return nil
+}
+
 type JSONSource struct {
 	Name string
 
 	dec *Decoder
+
+	io.Closer
 }
 
 var _ PipeSource = (*JSONSource)(nil)
 
-func NewJSONSource(name string, in io.Reader) *JSONSource {
+func NewJSONSource(name string, in io.ReadCloser) *JSONSource {
 	return &JSONSource{
 		Name: name,
 
 		dec: NewDecoder(in),
+
+		Closer: in,
 	}
 }
 

--- a/pkg/bass/session.go
+++ b/pkg/bass/session.go
@@ -132,10 +132,7 @@ func (session *Session) run(ctx context.Context, thunk Thunk, state RunState, ru
 		fsp := thunk.Cmd.FS
 
 		dir := fsp.Path.File.Dir()
-		state.Dir = &FSPath{
-			FS:   fsp.FS,
-			Path: FileOrDirPath{Dir: &dir},
-		}
+		state.Dir = NewFSPath(fsp.FS, FileOrDirPath{Dir: &dir})
 
 		module = NewRunScope(session.Root, state)
 

--- a/pkg/bass/session.go
+++ b/pkg/bass/session.go
@@ -70,6 +70,11 @@ func (session *Session) Load(ctx context.Context, thunk Thunk) (*Scope, error) {
 }
 
 func (session *Session) run(ctx context.Context, thunk Thunk, state RunState, runMain bool) (*Scope, error) {
+	custodian := NewCustodian()
+	defer custodian.Close()
+
+	ctx = WithCustodian(ctx, custodian)
+
 	var module *Scope
 
 	if thunk.Cmd.Cmd != nil {

--- a/pkg/bass/testdata/env.bass
+++ b/pkg/bass/testdata/env.bass
@@ -2,4 +2,4 @@
                   (with-env {:ABC "123"})))
         gotten enclosed)
 
-[gotten (enclosed)]
+(assert (= gotten (enclosed) "123"))

--- a/pkg/bass/testdata/load.bass
+++ b/pkg/bass/testdata/load.bass
@@ -1,6 +1,8 @@
 (import (load (*dir*/numbers.bass))
         inc)
 
-[(inc 0)
- (inc 1)
- (inc 2)]
+(assert
+  (= [(inc 0)
+      (inc 1)
+      (inc 2)]
+     [1 2 3]))

--- a/pkg/bass/testdata/read.bass
+++ b/pkg/bass/testdata/read.bass
@@ -1,0 +1,2 @@
+(assert (= (next (read opener :raw))
+           "hello"))

--- a/pkg/bass/testdata/run.bass
+++ b/pkg/bass/testdata/run.bass
@@ -1,6 +1,8 @@
 (def incs
   (read (*dir*/inc 0 1 2) :json))
 
-[(next incs)
- (next incs)
- (next incs)]
+(assert
+  (= [(next incs)
+      (next incs)
+      (next incs)]
+    [1 2 3]))

--- a/pkg/bass/testdata/use.bass
+++ b/pkg/bass/testdata/use.bass
@@ -2,6 +2,8 @@
      (.time)
      (*dir*/numbers.bass))
 
-(strings:join "," [(numbers:inc time:minute)
-                   (numbers:inc 1)
-                   (numbers:inc 2)])
+(assert
+  (= (strings:join "," [(numbers:inc time:minute)
+                        (numbers:inc 1)
+                        (numbers:inc 2)])
+     "61,2,3"))

--- a/pkg/bass/trace.go
+++ b/pkg/bass/trace.go
@@ -12,8 +12,6 @@ type Trace struct {
 	depth  int
 }
 
-type traceKey struct{}
-
 func (trace *Trace) Record(frame *Annotate) {
 	trace.frames[trace.depth%TraceSize] = frame
 	trace.depth++
@@ -71,6 +69,8 @@ func (trace *Trace) Frames() []*Annotate {
 func (trace *Trace) Reset() {
 	trace.depth = 0
 }
+
+type traceKey struct{}
 
 func WithTrace(ctx context.Context, trace *Trace) context.Context {
 	return context.WithValue(ctx, traceKey{}, trace)

--- a/std/root.bass
+++ b/std/root.bass
@@ -553,3 +553,13 @@
 ; => x
 (defop when [test & body] scope
   (eval [if test [do & body] null] scope))
+
+; evaluates the form and raises an error if it's not true
+;
+; => (assert (= (+ 2 2) 4))
+;
+; => (assert (= (+ 2 2) 5))
+(defop assert [form] scope
+  (if (eval form scope)
+    null
+    (error (str "assertion failed: " form))))


### PR DESCRIPTION
`(read)` no longer buffers the entire stream. instead, `PipeSource` is now `Close()`able and any opened source is registered with a `Custodian` for cleaning up.

Note that there isn't actually a `(close)` at this point since I'm not sure if people will even need to care about that level of detail. Would rather not have people feel the need to resource manage so carefully. Right now everything is closed automatically when a script runs or is loaded. We'll see if we need anything more than that.