### PR TITLE
redo `(assert)` for better error messages

### DIFF
--- a/bass/bass.bass
+++ b/bass/bass.bass
@@ -75,16 +75,14 @@
   (use (*dir*/buildkit.bass))
 
   (defn dist [src version os arch]
-    (subpath
-      (with-deps-and-shims
-        ($ make
+    (-> ($ make
            (str "VERSION=" version)
            (str "GOOS=" os)
            (str "GOARCH=" arch)
            "DESTDIR=./dist/"
            install)
-        src)
-      ./dist/))
+        (with-deps-and-shims src)
+        (subpath ./dist/)))
 
   ; compiles a bass binary for the given platform and puts it in an archive
   (defn build [src version os arch]
@@ -97,6 +95,7 @@
       (-> thunk
           (with-mount src ./)
           (with-mount built-shims/pkg/runtimes/bin/ ./pkg/runtimes/bin/)
+          with-go-cache
           (with-image (deps+go src)))))
 
   ; returns a thunk with the make targets built into the output directory, as
@@ -190,18 +189,20 @@
   ; returns a thunk that runs the tests
   (defn tests [src testflags]
     (-> ($ go test & $testflags)
+        with-go-cache
         (with-env {:SKIP_DAGGER_TESTS "true"})
         (with-bass-and-buildkitd src)))
 
   ; returns a thunk that will run the tests and return cover.html
   (defn coverage [src testflags]
     (from (with-bass-and-buildkitd src)
-      ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
-         --
-         -cover
-         -coverprofile ./cover.out
-         -covermode count
-         & $testflags)
+      (with-go-cache
+        ($ gotestsum --format testname --no-color=false --jsonfile ./tests.log
+           --
+           -cover
+           -coverprofile ./cover.out
+           -covermode count
+           & $testflags))
 
       ; report slow tests
       ($ gotestsum tool slowest --jsonfile ./tests.log --threshold "500ms")
@@ -242,3 +243,8 @@
   ; returns the github release module
   (defn release [token]
     (gh:release "vito/bass" token)))
+
+(defn with-go-cache [thunk]
+  (-> thunk
+      (with-mount (cache-dir "bass go mod") /go/pkg/mod/)
+      (with-mount (cache-dir "bass go cache") /root/.cache/go-build)))

--- a/pkg/bass/testdata/env.bass
+++ b/pkg/bass/testdata/env.bass
@@ -2,4 +2,4 @@
                   (with-env {:ABC "123"})))
         gotten enclosed)
 
-(assert (= gotten (enclosed) "123"))
+(assert = "123" gotten (enclosed))

--- a/pkg/bass/testdata/load.bass
+++ b/pkg/bass/testdata/load.bass
@@ -1,8 +1,7 @@
 (import (load (*dir*/numbers.bass))
         inc)
 
-(assert
-  (= [(inc 0)
-      (inc 1)
-      (inc 2)]
-     [1 2 3]))
+(assert = [1 2 3]
+  [(inc 0)
+   (inc 1)
+   (inc 2)])

--- a/pkg/bass/testdata/read.bass
+++ b/pkg/bass/testdata/read.bass
@@ -1,2 +1,1 @@
-(assert (= (next (read opener :raw))
-           "hello"))
+(assert = "hello" (next (read opener :raw)))

--- a/pkg/bass/testdata/run.bass
+++ b/pkg/bass/testdata/run.bass
@@ -1,8 +1,7 @@
 (def incs
   (read (*dir*/inc 0 1 2) :json))
 
-(assert
-  (= [(next incs)
-      (next incs)
-      (next incs)]
-    [1 2 3]))
+(assert = [1 2 3]
+  [(next incs)
+   (next incs)
+   (next incs)])

--- a/pkg/bass/testdata/use.bass
+++ b/pkg/bass/testdata/use.bass
@@ -2,8 +2,7 @@
      (.time)
      (*dir*/numbers.bass))
 
-(assert
-  (= (strings:join "," [(numbers:inc time:minute)
-                        (numbers:inc 1)
-                        (numbers:inc 2)])
-     "61,2,3"))
+(assert = "61,2,3"
+  (strings:join "," [(numbers:inc time:minute)
+                     (numbers:inc 1)
+                     (numbers:inc 2)]))

--- a/pkg/runtimes/suite.go
+++ b/pkg/runtimes/suite.go
@@ -18,6 +18,7 @@ import (
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/vito/bass/pkg/bass"
 	"github.com/vito/bass/pkg/basstest"
+	"github.com/vito/bass/pkg/cli"
 	"github.com/vito/bass/pkg/ioctx"
 	"github.com/vito/bass/pkg/runtimes/testdata"
 	"github.com/vito/bass/pkg/zapctx"
@@ -319,7 +320,7 @@ func Suite(t *testing.T, config bass.RuntimeConfig) {
 	}
 }
 
-func (test SuiteTest) Run(ctx context.Context, t *testing.T, env *bass.Scope) (bass.Value, error) {
+func (test SuiteTest) Run(ctx context.Context, t *testing.T, env *bass.Scope) (val bass.Value, err error) {
 	is := is.New(t)
 
 	ctx = zapctx.ToContext(ctx, zaptest.NewLogger(t))
@@ -331,6 +332,10 @@ func (test SuiteTest) Run(ctx context.Context, t *testing.T, env *bass.Scope) (b
 	displayBuf := new(bytes.Buffer)
 	ctx = ioctx.StderrToContext(ctx, displayBuf)
 	defer func() {
+		if err != nil {
+			cli.WriteError(ctx, err)
+		}
+
 		t.Logf("progress:\n%s", displayBuf.String())
 	}()
 

--- a/pkg/runtimes/testdata/export.bass
+++ b/pkg/runtimes/testdata/export.bass
@@ -3,7 +3,7 @@
 (defn check [file]
   (let [fi (meta file)
         content (-> file (read :raw) next)]
-    (assert (= fi:size (strings:length content)))
+    (assert = fi:size (strings:length content))
     fi:name))
 
 (def thunk
@@ -16,8 +16,8 @@
     [] false))
 
 (let [res (collect check (read (export thunk) :tar))]
-  (assert (includes? res "manifest.json"))
-  (assert (includes? res "index.json"))
-  (assert (includes? res "oci-layout"))
-  (assert (includes? res "blobs/"))
-  (assert (includes? res "blobs/sha256/")))
+  (assert includes? res "manifest.json")
+  (assert includes? res "index.json")
+  (assert includes? res "oci-layout")
+  (assert includes? res "blobs/")
+  (assert includes? res "blobs/sha256/"))

--- a/std/root.bass
+++ b/std/root.bass
@@ -551,15 +551,21 @@
 ; => (when false (def x :b))
 ;
 ; => x
+^:indent
 (defop when [test & body] scope
   (eval [if test [do & body] null] scope))
 
-; evaluates the form and raises an error if it's not true
+; applies the predicate to its arguments and errors if it returns false
 ;
-; => (assert (= (+ 2 2) 4))
+; By convention, the expected value should be passed as the first argument.
 ;
-; => (assert (= (+ 2 2) 5))
-(defop assert [form] scope
-  (if (eval form scope)
-    null
-    (error (str "assertion failed: " form))))
+; => (assert = 4 (+ 2 2))
+;
+; => (assert = 5 (+ 2 2))
+^:indent
+(defop assert [predicate & args] scope
+  (let [pred (eval predicate scope)
+        args (map (fn [a] (eval a scope)) args)]
+    (if (apply pred args)
+      null
+      (error (str "assertion failed: " [predicate & args])))))


### PR DESCRIPTION
Old: `(assert (= 1 foo))`, error: `assertion failed: (= 1 foo)`

New: `(assert = 1 foo)`, error: `assertion failed: (= 1 2)`

It's also marked as `^:indent` meaning you can format it like this:

```clojure
(assert = "1,2,3"
  (strings:join "," [1 2 3]))
```