### PR TITLE
add `(refute)`; opposite of `(assert)`

### DIFF
--- a/bass/bass.lock
+++ b/bass/bass.lock
@@ -450,7 +450,7 @@ memos: {
               }
               repository: "hello-world"
               tag: "latest"
-              digest: "sha256:ffb13da98453e0f04d33a6eee5bb8e46ee50d08ebe17735fc0779d0349e889e9"
+              digest: "sha256:4e83453afed1b4fa1a3500525091dbfca6ce1e66903fd4c01ff015dbcb1ba33e"
             }
           }
         }
@@ -500,7 +500,7 @@ memos: {
       }
       output: {
         string: {
-          value: "6ca3f15d70b739a7929886e20b61dbc4cbdc4e22"
+          value: "cbcb3f550f1208f8804c9f4e52921bd868856cd5"
         }
       }
     }
@@ -521,7 +521,7 @@ memos: {
       }
       output: {
         string: {
-          value: "a6c8ee8f81531c08c5136feca23cc6cca0be3b24"
+          value: "a18944bec00bd72341909da8cf0147a1e59884d5"
         }
       }
     }

--- a/std/root.bass
+++ b/std/root.bass
@@ -570,3 +570,18 @@
     (if (apply pred args)
       null
       (error (str "assertion failed: " [predicate & args])))))
+
+; applies the predicate to its arguments and errors if it returns true
+;
+; By convention, the expected value should be passed as the first argument.
+;
+; => (refute = 4 (+ 2 2))
+;
+; => (refute = 5 (+ 2 2))
+^:indent
+(defop refute [predicate & args] scope
+  (let [pred (eval predicate scope)
+        args (map (fn [a] (eval a scope)) args)]
+    (if (apply pred args)
+      (error (str "negative assertion failed: " [predicate & args]))
+      null)))

--- a/std/root.bass
+++ b/std/root.bass
@@ -583,5 +583,5 @@
   (let [pred (eval predicate scope)
         args (map (fn [a] (eval a scope)) args)]
     (if (apply pred args)
-      (error (str "negative assertion failed: " [predicate & args]))
+      (error (str "refutation failed: " [predicate & args]))
       null)))


### PR DESCRIPTION
Usage:

```clojure
(refute = 5 (+ 2 2))
```