### PR TITLE
Dockerfiles: add Dagger support, stop respecting workdir

### DIFF
--- a/bass/bass.lock
+++ b/bass/bass.lock
@@ -500,7 +500,7 @@ memos: {
       }
       output: {
         string: {
-          value: "cbcb3f550f1208f8804c9f4e52921bd868856cd5"
+          value: "2170cb09168d2dbb3f05f5eca44c9c2c10ffe788"
         }
       }
     }
@@ -521,7 +521,7 @@ memos: {
       }
       output: {
         string: {
-          value: "a18944bec00bd72341909da8cf0147a1e59884d5"
+          value: "9141da72318c09fe61e12c8c2166ffad6e8c6413"
         }
       }
     }

--- a/bass/bass.lock
+++ b/bass/bass.lock
@@ -500,7 +500,7 @@ memos: {
       }
       output: {
         string: {
-          value: "2170cb09168d2dbb3f05f5eca44c9c2c10ffe788"
+          value: "5fbaf17c298ed8f0f9bd5fdbfb8a05abe3471785"
         }
       }
     }

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -1476,7 +1476,6 @@ func (b *buildkitBuilder) image(ctx context.Context, image *bass.ThunkImage) (In
 		}
 
 		ib.Output = ib.FS
-		ib.OutputSourcePath = ib.Config.WorkingDir
 		ib.NeedsInsecure = needsInsecure
 		return ib, nil
 	}
@@ -1749,10 +1748,6 @@ func (proxy *statusProxy) Wait() {
 
 func (proxy *statusProxy) NiceError(msg string, err error) bass.NiceError {
 	return proxy.prog.WrapError(msg, err)
-}
-
-func getWorkdir(st llb.ExecState, _ string) llb.State {
-	return st.GetMount(workDir)
 }
 
 func dialBuildkit(ctx context.Context, addr string, installation string, certsDir string) (*bkclient.Client, error) {

--- a/pkg/runtimes/buildkit.go
+++ b/pkg/runtimes/buildkit.go
@@ -879,7 +879,7 @@ func (b *buildkitBuilder) Build(
 		llb.AddMount("/dev/shm", llb.Scratch(), llb.Tmpfs()),
 		llb.AddMount(ioDir, llb.Scratch().File(
 			llb.Mkfile("in", 0600, cmdPayload),
-			llb.WithCustomName("[hide] mount command json"),
+			llb.WithCustomNamef("[hide] mount command json for %s", thunk.String()),
 		)),
 		llb.AddMount(shimExePath, shimExe, llb.SourcePath("run")),
 		llb.With(llb.Dir(workDir)),

--- a/pkg/runtimes/dagger_test.go
+++ b/pkg/runtimes/dagger_test.go
@@ -24,7 +24,6 @@ func TestDaggerRuntime(t *testing.T) {
 		Runtime:  runtimes.DaggerName,
 	}, runtimes.SkipSuites(
 		"tls.bass",
-		"docker-build.bass",
 		"cache-cmd.bass",
 	))
 }

--- a/pkg/runtimes/testdata/docker-build.bass
+++ b/pkg/runtimes/testdata/docker-build.bass
@@ -1,34 +1,38 @@
 (defn read-all [thunk]
   (-> thunk (read :raw) next))
 
+(refute = "/wd"
+  (read-all
+    (from (docker-build *dir*/docker-build/ {:os "linux"})
+      ($ pwd))))
+
 (assert = "hello from Dockerfile\n"
   (read-all
     (from (docker-build *dir*/docker-build/ {:os "linux"})
-      ($ pwd)
-      ($ cat ./wd-file))))
+      ($ cat /wd/wd-file))))
 
 (assert = "hello from Dockerfile.alt\n"
   (read-all
     (from (docker-build *dir*/docker-build/ {:os "linux"}
                         :dockerfile ./Dockerfile.alt)
-      ($ cat ./wd-file))))
+      ($ cat /wd/wd-file))))
 
 
 (assert = "hello from alt stage in Dockerfile\n"
   (read-all
     (from (docker-build *dir*/docker-build/ {:os "linux"}
                         :target "alt")
-      ($ cat ./wd-file))))
+      ($ cat /wd/wd-file))))
 
 (assert = "hello from Dockerfile with message sup\n"
   (read-all
     (from (docker-build *dir*/docker-build/ {:os "linux"}
                         :target "arg"
                         :args {:MESSAGE "sup"})
-      ($ cat ./wd-file))))
+      ($ cat /wd/wd-file))))
 
 (assert = "hello from Dockerfile with env bar\nbar\n"
   (read-all
     (from (docker-build *dir*/docker-build/ {:os "linux"}
                         :target "env")
-      ($ sh -c "cat ./wd-file; echo $FOO"))))
+      ($ sh -c "cat /wd/wd-file; echo $FOO"))))

--- a/pkg/runtimes/testdata/docker-build/Dockerfile
+++ b/pkg/runtimes/testdata/docker-build/Dockerfile
@@ -3,13 +3,16 @@ WORKDIR /wd
 RUN echo hello from Dockerfile > wd-file
 
 FROM alpine AS alt
+WORKDIR /wd
 RUN echo hello from alt stage in Dockerfile > wd-file
 
 FROM alpine AS arg
+WORKDIR /wd
 ARG MESSAGE
 RUN echo hello from Dockerfile with message $MESSAGE > wd-file
 
 FROM alpine AS env
+WORKDIR /wd
 ENV FOO=bar
 RUN echo hello from Dockerfile with env $FOO > wd-file
 


### PR DESCRIPTION
Dagger: now down to just 2 failing tests: TLS support + running cache paths.

Buildkit: don't have thunks inherit the `WORKDIR` from the Dockerfile, since this was inconsistent with everything else.