### PR TITLE
don't detect tty on stdin

### DIFF
--- a/pkg/cli/progress.go
+++ b/pkg/cli/progress.go
@@ -111,7 +111,6 @@ var fancy bool
 
 func init() {
 	fancy = isatty.IsTerminal(os.Stdout.Fd()) ||
-		isatty.IsTerminal(os.Stdin.Fd()) ||
 		isatty.IsTerminal(os.Stderr.Fd())
 
 	if os.Getenv("BASS_FANCY_TUI") != "" {


### PR DESCRIPTION
* need to detect stdout for obvious reasons
* need to detect stderr because stdout might be piped to something, but we still want to render the fancy UI in that case
* need to *not* detect stdin to support things like dagger run. use case:
  - want to forward stdin to command to support piping to it
  - don't want it to be treated like a tty because dagger run tui is going to intercept all interactive input anyway, and rendering a fancy UI within a fancy UI doesn't seem wise